### PR TITLE
Change our "tty" enablement code to not set sasl_error_logger for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ ENV RABBITMQ_VERSION 3.4.3-1
 
 RUN apt-get update && apt-get install -y rabbitmq-server=$RABBITMQ_VERSION --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# get logs to stdout (thanks to http://www.superpumpup.com/docker-rabbitmq-stdout)
-RUN grep -vE '^\s+-rabbit .*error_logger.*' /usr/lib/rabbitmq/lib/rabbitmq_server-*/sbin/rabbitmq-server > /tmp/rabbitmq-server \
+# get logs to stdout (thanks to http://www.superpumpup.com/docker-rabbitmq-stdout for inspiration)
+# TODO figure out what we'd need to do to add "(sasl_)?" to this sed and have it work ("{"init terminating in do_boot",{rabbit,failure_during_boot,{error,{cannot_log_to_tty,sasl_report_tty_h,not_installed}}}}")
+RUN sed -E 's!^(\s*-rabbit\s+error_logger)\s+\S*!\1 tty!' /usr/lib/rabbitmq/lib/rabbitmq_server-*/sbin/rabbitmq-server > /tmp/rabbitmq-server \
 	&& chmod +x /tmp/rabbitmq-server \
 	&& mv /tmp/rabbitmq-server /usr/lib/rabbitmq/lib/rabbitmq_server-*/sbin/rabbitmq-server
-ENV RABBITMQ_SERVER_START_ARGS -eval error_logger:tty(true).
 
 RUN echo '[{rabbit, [{loopback_users, []}]}].' > /etc/rabbitmq/rabbitmq.config
 


### PR DESCRIPTION
This also changes our setting of `error_logger` to be more robust and to leave `RABBITMQ_SERVER_START_ARGS` as the user-available knob it's supposed to be.

Fixes #2