### PR TITLE
Updated Erlang version to 17.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:wheezy
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r rabbitmq && useradd -r -d /var/lib/rabbitmq -m -g rabbitmq rabbitmq
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv D208507CA14F4FCA
+RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 434975BD900CCBE4F7EE1B1ED208507CA14F4FCA
 RUN echo 'deb http://packages.erlang-solutions.com/debian wheezy contrib' > /etc/apt/sources.list.d/erlang.list
 
 # http://www.rabbitmq.com/install-debian.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM debian:wheezy
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r rabbitmq && useradd -r -d /var/lib/rabbitmq -m -g rabbitmq rabbitmq
 
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv D208507CA14F4FCA
+RUN echo 'deb http://packages.erlang-solutions.com/debian wheezy contrib' > /etc/apt/sources.list.d/erlang.list
+
 # http://www.rabbitmq.com/install-debian.html
 # "Please note that the word testing in this line refers to the state of our release of RabbitMQ, not any particular Debian distribution."
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys F78372A06FF50C80464FC1B4F7B8CEA6056E8E56

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM debian:wheezy
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r rabbitmq && useradd -r -d /var/lib/rabbitmq -m -g rabbitmq rabbitmq
 
+# Add the officially endorsed Erlang debian repository:
+# See:
+#  - http://www.erlang.org/download.html
+#  - https://www.erlang-solutions.com/downloads/download-erlang-otp
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 434975BD900CCBE4F7EE1B1ED208507CA14F4FCA
 RUN echo 'deb http://packages.erlang-solutions.com/debian wheezy contrib' > /etc/apt/sources.list.d/erlang.list
 


### PR DESCRIPTION
Updated Erlang version to 17.4, installed from the official Erlang debian repo, in case the switch to Debian Jessie can't be done right now.

Fixes #8