### PR TITLE
Adding support for overriding the Erlang Cookie

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,8 +2,9 @@
 set -e
 
 if [ "$1" = 'rabbitmq-server' ]; then
-	if [ "${ERLANG_COOKIE}" -n ]; then
+	if [ -n "${ERLANG_COOKIE}" ]; then
 		echo ${ERLANG_COOKIE} > /var/lib/rabbitmq/.erlang.cookie
+		chmod 600 /var/lib/rabbitmq/.erlang.cookie
 	fi
 	chown -R rabbitmq /var/lib/rabbitmq
 	set -- gosu rabbitmq "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,9 @@
 set -e
 
 if [ "$1" = 'rabbitmq-server' ]; then
+	if [ "${ERLANG_COOKIE}" -n ]; then
+		echo ${ERLANG_COOKIE} > /var/lib/rabbitmq/.erlang.cookie
+	fi
 	chown -R rabbitmq /var/lib/rabbitmq
 	set -- gosu rabbitmq "$@"
 fi


### PR DESCRIPTION
`docker_entrypoint.sh` script now supports overriding the Erlang cookie via the environment variable `ERLANG_COOKIE`

Helpfull for clustering.