### PR TITLE
Improve ".erlang.cookie" file management by adding RABBITMQ_ERLANG_COOKIE for specifying it directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ RUN echo '[{rabbit, [{loopback_users, []}]}].' > /etc/rabbitmq/rabbitmq.config
 
 VOLUME /var/lib/rabbitmq
 
+# add a symlink to the .erlang.cookie in /root so we can "docker exec rabbitmqctl ..." without gosu
+RUN ln -sf /var/lib/rabbitmq/.erlang.cookie /root/
+
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -e
 
+if [ "$RABBITMQ_ERLANG_COOKIE" ]; then
+	cookieFile='/var/lib/rabbitmq/.erlang.cookie'
+	if [ -e "$cookieFile" ]; then
+		if [ "$(cat "$cookieFile" 2>/dev/null)" != "$RABBITMQ_ERLANG_COOKIE" ]; then
+			echo >&2
+			echo >&2 "warning: $cookieFile contents do not match RABBITMQ_ERLANG_COOKIE"
+			echo >&2
+		fi
+	else
+		echo "$RABBITMQ_ERLANG_COOKIE" > "$cookieFile"
+		chmod 600 "$cookieFile"
+		chown rabbitmq "$cookieFile"
+	fi
+fi
+
 if [ "$1" = 'rabbitmq-server' ]; then
 	configs=(
 		# https://www.rabbitmq.com/configure.html


### PR DESCRIPTION
This allows for direct, simple control over the contents of the `.erlang.cookie` file, which allows for much simpler container interconnections.

This also symlinks that file into `/root` so that the root user will pick it up properly without additional changes.

Closes #25
Fixes #29

As an example of what this enables:
```console
$ docker run -it -d --name rabbit --hostname some-hostname -e RABBITMQ_ERLANG_COOKIE='something something something' rabbitmq
$ docker exec -it rabbit rabbitmqctl list_users
Listing users ...
guest	[administrator]
$ docker run -it --rm --link rabbit:some-hostname -e RABBITMQ_ERLANG_COOKIE='something something something' rabbitmq bash
root@d2f270ad4fba:/# rabbitmqctl -n rabbit@some-hostname list_users
Listing users ...
guest	[administrator]
```