### PR TITLE
Additional config parameters

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,6 +22,7 @@ if [ "$1" = 'rabbitmq-server' ]; then
 		default_vhost
 		default_user
 		default_pass
+		cluster_nodes
 	)
 
 	haveConfig=
@@ -45,7 +46,7 @@ if [ "$1" = 'rabbitmq-server' ]; then
 			val="${!var}"
 			[ "$val" ] || continue
 			cat >> /etc/rabbitmq/rabbitmq.config <<-EOC
-			      {$conf, <<"$val">>},
+			      {$conf, $val},
 			EOC
 		done
 		cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'


### PR DESCRIPTION
Would it be logical to add all config parameters described in https://www.rabbitmq.com/configure.html?

Note this PR removes the "<< >>" from var expansion. User is expected to write them himself.
Perhaps I should update the documentation together?