### PR TITLE
Add tini for handling signals appropriately

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,12 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
+# grab tini for signal processing and zombie killing
+RUN set -x \
+	&& curl -fSL "https://github.com/krallin/tini/releases/download/v0.5.0/tini" -o /usr/local/bin/tini \
+	&& chmod +x /usr/local/bin/tini \
+	&& tini -h
+
 # Add the officially endorsed Erlang debian repository:
 # See:
 #  - http://www.erlang.org/download.html

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -57,7 +57,7 @@ if [ "$1" = 'rabbitmq-server' ]; then
 	fi
 
 	chown -R rabbitmq /var/lib/rabbitmq
-	set -- gosu rabbitmq "$@"
+	set -- gosu rabbitmq tini -- "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
This is a short-term workaround while we wait for upstream to implement proper handling of SIGTERM.  See https://github.com/rabbitmq/rabbitmq-server/issues/234.

Fixes #35