### PR TITLE
Changed rabbitmq user/group to be non-system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:wheezy
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN groupadd -r rabbitmq && useradd -r -d /var/lib/rabbitmq -m -g rabbitmq rabbitmq
+RUN groupadd rabbitmq && useradd -d /var/lib/rabbitmq -m -g rabbitmq rabbitmq
 
 RUN apt-get update && apt-get install -y curl ca-certificates --no-install-recommends && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I'm doing development using Vagrant, and I have `/workspace` mounted from my local machine (OSX). Regardless of local ownership, this directory shows up owned by `vagrant:vagrant` inside of the VM. Commands like `chown` don't change this, so if I share this directory into the `rabbitmq` container for persistence, it shows up owned by UID 1000. The result is that `rabbitmq` can't create `mnesia` or any data within that directory.
The cause is that the user and group are created as system objects, with UID/GID 999. If we remove the `-r` parameter, they'll be created as UID 1000, which maps to the `vagrant` user within the VM and allows for the content creation.
The use of system users is good in theory but may not be absolutely necessary. In this case I've identified a situation where that parameter breaks the container's usability, so I'm providing a pull request that removes the `-r` parameters.