### PR TITLE
Update to 3.5.5, removing tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,6 @@ RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/dow
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu
 
-# grab tini for signal processing and zombie killing
-RUN set -x \
-	&& curl -fSL "https://github.com/krallin/tini/releases/download/v0.5.0/tini" -o /usr/local/bin/tini \
-	&& chmod +x /usr/local/bin/tini \
-	&& tini -h
-
 # Add the officially endorsed Erlang debian repository:
 # See:
 #  - http://www.erlang.org/download.html
@@ -35,7 +29,7 @@ ENV RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys F78372A06FF50C80464FC1B4F7B8CEA6056E8E56
 RUN echo 'deb http://www.rabbitmq.com/debian/ testing main' > /etc/apt/sources.list.d/rabbitmq.list
 
-ENV RABBITMQ_VERSION 3.5.4-1
+ENV RABBITMQ_VERSION 3.5.5-1
 
 RUN apt-get update && apt-get install -y rabbitmq-server=$RABBITMQ_VERSION --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -57,7 +57,7 @@ if [ "$1" = 'rabbitmq-server' ]; then
 	fi
 
 	chown -R rabbitmq /var/lib/rabbitmq
-	set -- gosu rabbitmq tini -- "$@"
+	set -- gosu rabbitmq "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
See https://github.com/rabbitmq/rabbitmq-server/pull/258 for the upstream PR which makes tini no longer necessary (and is included in a release as of 3.5.5).

Thanks @dumbbell! :heart: