### PR TITLE
README: clarify who maintains the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About this Repo
 
-This is the Git repo of the official Docker image for [rabbitmq](https://registry.hub.docker.com/_/rabbitmq/). See the
+This is the Git repo of the official [Docker image for rabbitmq](https://registry.hub.docker.com/_/rabbitmq/)  maintained by Docker, Inc. See the
 Hub page for the full readme on how to use the Docker image and for information
 regarding contributing and issues.
 


### PR DESCRIPTION
We've seen some folks interpret "official image" as "maintained by the RabbitMQ team", so perhaps it's worth clarifying.