### PR TITLE
Add ports 4369 & 25672 to EXPOSE instruction in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,5 +46,5 @@ RUN ln -sf /var/lib/rabbitmq/.erlang.cookie /root/
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-EXPOSE 5672
+EXPOSE 5672 4369 25672
 CMD ["rabbitmq-server"]


### PR DESCRIPTION
These ports are used for clustering and RabbitMQ listens on them by default (whether or not the user is using clustering).