### PR TITLE
SSL and FDN support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,10 @@ RUN echo 'deb http://www.rabbitmq.com/debian testing main' > /etc/apt/sources.li
 
 ENV RABBITMQ_VERSION 3.5.6-1
 
-RUN apt-get update && \
-	apt-get install -y erlang erlang-mnesia erlang-public-key erlang-crypto erlang-ssl \
-		erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap && \
-	apt-get install -y rabbitmq-server=$RABBITMQ_VERSION --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		erlang erlang-mnesia erlang-public-key erlang-crypto erlang-ssl erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap \
+		rabbitmq-server=$RABBITMQ_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
 
 # /usr/sbin/rabbitmq-server has some irritating behavior, and only exists to "su - rabbitmq /usr/lib/rabbitmq/bin/rabbitmq-server ..."
 ENV PATH /usr/lib/rabbitmq/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,10 @@ RUN echo 'deb http://www.rabbitmq.com/debian testing main' > /etc/apt/sources.li
 
 ENV RABBITMQ_VERSION 3.5.6-1
 
-RUN apt-get update && apt-get install -y rabbitmq-server=$RABBITMQ_VERSION --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+	apt-get install -y erlang erlang-mnesia erlang-public-key erlang-crypto erlang-ssl \
+		erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap && \
+	apt-get install -y rabbitmq-server=$RABBITMQ_VERSION --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 # /usr/sbin/rabbitmq-server has some irritating behavior, and only exists to "su - rabbitmq /usr/lib/rabbitmq/bin/rabbitmq-server ..."
 ENV PATH /usr/lib/rabbitmq/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update && apt-get install -y curl ca-certificates --no-install-recom
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$(dpkg --print-architecture).asc" \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.6/gosu-$(dpkg --print-architecture)" \
+	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.6/gosu-$(dpkg --print-architecture).asc" \
 	&& gpg --verify /usr/local/bin/gosu.asc \
 	&& rm /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,5 @@ RUN ln -sf /var/lib/rabbitmq/.erlang.cookie /root/
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-EXPOSE 5672 4369 25672
+EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,11 +2,11 @@
 set -e
 
 # If long & short hostnames are not the same, use long hostnames
-if ! [[ $(hostname) == $(hostname -s) ]]; then
+if [ $(hostname) != $(hostname -s) ]; then
 	export RABBITMQ_USE_LONGNAME=true
 fi
 
-if ! [[ -z ${RABBIT_SSL_CERT_FILE+x} ]] || ! [[ -z ${RABBIT_SSL_KEY_FILE+x} ]] || ! [[ -z ${RABBIT_SSL_CA_FILE+x} ]]; then
+if [ ${RABBITMQ_SSL_CERT_FILE:+x} -a ${RABBITMQ_SSL_KEY_FILE:+x} -a ${RABBITMQ_SSL_CA_FILE:+x} ]; then
 	use_ssl="yes"
 fi
 
@@ -50,14 +50,14 @@ if [ "$1" = 'rabbitmq-server' ]; then
 			    [
 		EOH
 		
-		if [[ "${use_ssl}" == "yes" ]]; then
+		if [ "${use_ssl}" = "yes" ]; then
 			cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
 			      { tcp_listeners, [ ] },
 			      { ssl_listeners, [ 5671 ] },
 			      { ssl_options,  [ 
-			        { certfile,   "$RABBIT_SSL_CERT_FILE" },
-			        { keyfile,    "$RABBIT_SSL_KEY_FILE" },
-			        { cacertfile, "$RABBIT_SSL_CA_FILE" },
+			        { certfile,   "$RABBITMQ_SSL_CERT_FILE" },
+			        { keyfile,    "$RABBITMQ_SSL_KEY_FILE" },
+			        { cacertfile, "$RABBITMQ_SSL_CA_FILE" },
 			        { verify,   verify_peer },
 			        { fail_if_no_peer_cert, true } ] },
 			EOS
@@ -88,14 +88,14 @@ if [ "$1" = 'rabbitmq-server' ]; then
 				      { listener, [
 			EOF
 
-			if [[ "${use_ssl}" == "yes" ]]; then
+			if [ "${use_ssl}" = "yes" ]; then
 				cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
 				      { port, 15671 }, 
 				      { ssl, true },
 				      { ssl_opts, [ 
-				          { certfile,   "$RABBIT_SSL_CERT_FILE" },
-				          { keyfile,    "$RABBIT_SSL_KEY_FILE" },
-				          { cacertfile, "$RABBIT_SSL_CA_FILE" },
+				          { certfile,   "$RABBITMQ_SSL_CERT_FILE" },
+				          { keyfile,    "$RABBITMQ_SSL_KEY_FILE" },
+				          { cacertfile, "$RABBITMQ_SSL_CA_FILE" },
 				      { verify,   verify_none },
 				      { fail_if_no_peer_cert, false } ] } ] }
 				EOS
@@ -116,9 +116,9 @@ if [ "$1" = 'rabbitmq-server' ]; then
 		EOF
 	fi
 
-	if [[ "${use_ssl}" == "yes" ]]; then
+	if [ "${use_ssl}" = "yes" ]; then
 		# Create combined cert
-		cat ${RABBIT_SSL_CERT_FILE} ${RABBIT_SSL_KEY_FILE} > /tmp/combined.pem
+		cat ${RABBITMQ_SSL_CERT_FILE} ${RABBITMQ_SSL_KEY_FILE} > /tmp/combined.pem
 		chmod 0400 /tmp/combined.pem
 
 		# More ENV vars for make clustering happiness
@@ -129,7 +129,7 @@ if [ "$1" = 'rabbitmq-server' ]; then
 		export RABBITMQ_CTL_ERL_ARGS="-pa ${ERL_SSL_PATH} -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
 
 		echo "Launching RabbitMQ with SSL..."
-		echo -e " - RABBIT_SSL_CERT_FILE: $RABBIT_SSL_CERT_FILE\n - RABBIT_SSL_KEY_FILE: $RABBIT_SSL_KEY_FILE\n - RABBIT_SSL_CA_FILE: $RABBIT_SSL_CA_FILE"
+		echo -e " - RABBITMQ_SSL_CERT_FILE: $RABBITMQ_SSL_CERT_FILE\n - RABBITMQ_SSL_KEY_FILE: $RABBITMQ_SSL_KEY_FILE\n - RABBITMQ_SSL_CA_FILE: $RABBITMQ_SSL_CA_FILE"
 	else
 		echo "Launching RabbitMQ..."
 	fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# If long & short hostnames are not the same, use long hostnames
+if ! [[ $(hostname) == $(hostname -s) ]]; then
+	export RABBITMQ_USE_LONGNAME=true
+fi
 if [ "$RABBITMQ_ERLANG_COOKIE" ]; then
 	cookieFile='/var/lib/rabbitmq/.erlang.cookie'
 	if [ -e "$cookieFile" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -80,7 +80,8 @@ if [ "$1" = 'rabbitmq-server' ]; then
 			      {loopback_users, []}
 		EOF
 
-		if [ "$RABBITMQ_MANAGEMENT_ENABLED" ]; then
+		# If management plugin is installed, then generate config consider this
+		if [ "$(rabbitmq-plugins list -m -e rabbitmq_management)" ]; then
 			cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
 				    ]
 				  },

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -80,7 +80,7 @@ if [ "$1" = 'rabbitmq-server' ]; then
 			      {loopback_users, []}
 		EOF
 
-		if [ "$RABBIT_MANAGEMENT_ENABLED" ]; then
+		if [ "$RABBITMQ_MANAGEMENT_ENABLED" ]; then
 			cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
 				    ]
 				  },

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -e
 
-# If long & short hostnames are not the same, use long hostnames
-if [ $(hostname) != $(hostname -s) ]; then
-	export RABBITMQ_USE_LONGNAME=true
-fi
+ssl=
 
 if [ ${RABBITMQ_SSL_CERT_FILE:+x} -a ${RABBITMQ_SSL_KEY_FILE:+x} -a ${RABBITMQ_SSL_CA_FILE:+x} ]; then
-	use_ssl="yes"
+	ssl=1
+fi
+
+# If long & short hostnames are not the same, use long hostnames
+if [ "$(hostname)" != "$(hostname -s)" ]; then
+	export RABBITMQ_USE_LONGNAME=true
 fi
 
 if [ "$RABBITMQ_ERLANG_COOKIE" ]; then
@@ -50,7 +52,7 @@ if [ "$1" = 'rabbitmq-server' ]; then
 			    [
 		EOH
 		
-		if [ "${use_ssl}" = "yes" ]; then
+		if [ "$ssl" ]; then
 			cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
 			      { tcp_listeners, [ ] },
 			      { ssl_listeners, [ 5671 ] },
@@ -89,7 +91,7 @@ if [ "$1" = 'rabbitmq-server' ]; then
 				      { listener, [
 			EOF
 
-			if [ "${use_ssl}" = "yes" ]; then
+			if [ "$ssl" ]; then
 				cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
 				      { port, 15671 }, 
 				      { ssl, true },
@@ -117,22 +119,17 @@ if [ "$1" = 'rabbitmq-server' ]; then
 		EOF
 	fi
 
-	if [ "${use_ssl}" = "yes" ]; then
+	if [ "$ssl" ]; then
 		# Create combined cert
-		cat ${RABBITMQ_SSL_CERT_FILE} ${RABBITMQ_SSL_KEY_FILE} > /tmp/combined.pem
+		cat "$RABBITMQ_SSL_CERT_FILE" "$RABBITMQ_SSL_KEY_FILE" > /tmp/combined.pem
 		chmod 0400 /tmp/combined.pem
 
 		# More ENV vars for make clustering happiness
 		# we don't handle clustering in this script, but these args should ensure
 		# clustered SSL-enabled members will talk nicely
-		export ERL_SSL_PATH=`erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell`
-		export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa ${ERL_SSL_PATH} -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
-		export RABBITMQ_CTL_ERL_ARGS="-pa ${ERL_SSL_PATH} -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
-
-		echo "Launching RabbitMQ with SSL..."
-		echo -e " - RABBITMQ_SSL_CERT_FILE: $RABBITMQ_SSL_CERT_FILE\n - RABBITMQ_SSL_KEY_FILE: $RABBITMQ_SSL_KEY_FILE\n - RABBITMQ_SSL_CA_FILE: $RABBITMQ_SSL_CA_FILE"
-	else
-		echo "Launching RabbitMQ..."
+		export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
+		export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
+		export RABBITMQ_CTL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
 	fi
 
 	chown -R rabbitmq /var/lib/rabbitmq

--- a/management/Dockerfile
+++ b/management/Dockerfile
@@ -1,6 +1,6 @@
 FROM rabbitmq
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
-ENV RABBIT_MANAGEMENT_ENABLED yes
+ENV RABBITMQ_MANAGEMENT_ENABLED yes
 
 EXPOSE 15671 15672

--- a/management/Dockerfile
+++ b/management/Dockerfile
@@ -2,4 +2,4 @@ FROM rabbitmq
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
 
-EXPOSE 15672
+EXPOSE 15671 15672

--- a/management/Dockerfile
+++ b/management/Dockerfile
@@ -1,5 +1,6 @@
 FROM rabbitmq
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
+ENV RABBIT_MANAGEMENT_ENABLED yes
 
 EXPOSE 15671 15672

--- a/management/Dockerfile
+++ b/management/Dockerfile
@@ -1,6 +1,5 @@
 FROM rabbitmq
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
-ENV RABBITMQ_MANAGEMENT_ENABLED yes
 
 EXPOSE 15671 15672


### PR DESCRIPTION
This is "cherrypick" of SSL and FDN support from [alpine-rmq](https://github.com/gonkulator/alpine-rmq). Entrypoint is improved to support SSL configuration generation. Updated gosu to v1.6.

New environment variables:
- RABBIT_SSL_CERT_FILE (`certfile`)
- RABBIT_SSL_KEY_FILE (`keyfile`)
- RABBIT_SSL_CA_FILE (`cacertfile`)
- RABBIT_MANAGEMENT_ENABLED (flag used in Dockerfile with management plugin)