### PR TITLE
Only be root when necessary, so that `--user` works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ ENV PATH /usr/lib/rabbitmq/bin:$PATH
 
 RUN echo '[{rabbit, [{loopback_users, []}]}].' > /etc/rabbitmq/rabbitmq.config
 
+# set home so that any `--user` knows where to put the erlang cookie
+ENV HOME /var/lib/rabbitmq
+
 VOLUME /var/lib/rabbitmq
 
 # add a symlink to the .erlang.cookie in /root so we can "docker exec rabbitmqctl ..." without gosu

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# allow the container to be stated with `--user`
+# allow the container to be started with `--user`
 if [ "$1" = 'rabbitmq-server' -a "$(id -u)" = '0' ]; then
 	chown -R rabbitmq /var/lib/rabbitmq
 	exec gosu rabbitmq "$BASH_SOURCE" "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# allow the container to be stated with `--user`
+if [ "$1" = 'rabbitmq-server' -a "$(id -u)" = '0' ]; then
+	chown -R rabbitmq /var/lib/rabbitmq
+	exec gosu rabbitmq "$BASH_SOURCE" "$@"
+fi
+
 ssl=
 if [ "$RABBITMQ_SSL_CERT_FILE" -a "$RABBITMQ_SSL_KEY_FILE" -a "$RABBITMQ_SSL_CA_FILE" ]; then
 	ssl=1
@@ -22,7 +28,6 @@ if [ "$RABBITMQ_ERLANG_COOKIE" ]; then
 	else
 		echo "$RABBITMQ_ERLANG_COOKIE" > "$cookieFile"
 		chmod 600 "$cookieFile"
-		chown rabbitmq "$cookieFile"
 	fi
 fi
 
@@ -126,7 +131,6 @@ if [ "$1" = 'rabbitmq-server' ]; then
 		# Create combined cert
 		cat "$RABBITMQ_SSL_CERT_FILE" "$RABBITMQ_SSL_KEY_FILE" > /tmp/combined.pem
 		chmod 0400 /tmp/combined.pem
-		chown rabbitmq /tmp/combined.pem
 
 		# More ENV vars for make clustering happiness
 		# we don't handle clustering in this script, but these args should ensure
@@ -135,9 +139,6 @@ if [ "$1" = 'rabbitmq-server' ]; then
 		export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
 		export RABBITMQ_CTL_ERL_ARGS="$RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS"
 	fi
-
-	chown -R rabbitmq /var/lib/rabbitmq
-	set -- gosu rabbitmq "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
If a user mounts a directory to `/var/lib/rabbitmq`, while using `--user` on the `docker run` then they are responsible to set the permissions.  This should also help OSX users when sharing a directory from the host:

```console
$ docker run -d -v /Users/...rabbitdir/:/var/lib/rabbitmq/ --user 1000:50 rabbitmq
```


Replaces #40