### PR TITLE
Always set SSL environment settings

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -134,7 +134,7 @@ if [ "$ssl" ]; then
 	# As a workaround prefix the combined cert with the username so each user only operates on the file they control.
 	combined_file="/tmp/$(id -un)_combined.pem"
 	cat "$RABBITMQ_SSL_CERT_FILE" "$RABBITMQ_SSL_KEY_FILE" > $combined_file
-	chmod 0400 $combined_file
+	chmod 0600 $combined_file
 
 	# More ENV vars for make clustering happiness
 	# we don't handle clustering in this script, but these args should ensure

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -126,19 +126,19 @@ if [ "$1" = 'rabbitmq-server' ]; then
 			].
 		EOF
 	fi
+fi
 
-	if [ "$ssl" ]; then
-		# Create combined cert
-		cat "$RABBITMQ_SSL_CERT_FILE" "$RABBITMQ_SSL_KEY_FILE" > /tmp/combined.pem
-		chmod 0400 /tmp/combined.pem
+if [ "$ssl" ]; then
+	# Create combined cert
+	cat "$RABBITMQ_SSL_CERT_FILE" "$RABBITMQ_SSL_KEY_FILE" > /tmp/combined.pem
+	chmod 0400 /tmp/combined.pem
 
-		# More ENV vars for make clustering happiness
-		# we don't handle clustering in this script, but these args should ensure
-		# clustered SSL-enabled members will talk nicely
-		export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
-		export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
-		export RABBITMQ_CTL_ERL_ARGS="$RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS"
-	fi
+	# More ENV vars for make clustering happiness
+	# we don't handle clustering in this script, but these args should ensure
+	# clustered SSL-enabled members will talk nicely
+	export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
+	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
+	export RABBITMQ_CTL_ERL_ARGS="$RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS"
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,114 +31,112 @@ if [ "$RABBITMQ_ERLANG_COOKIE" ]; then
 	fi
 fi
 
-if [ "$1" = 'rabbitmq-server' ]; then
-	configs=(
-		# https://www.rabbitmq.com/configure.html
-		default_pass
-		default_user
-		default_vhost
-		ssl_ca_file
-		ssl_cert_file
-		ssl_key_file
-	)
+configs=(
+	# https://www.rabbitmq.com/configure.html
+	default_pass
+	default_user
+	default_vhost
+	ssl_ca_file
+	ssl_cert_file
+	ssl_key_file
+)
 
-	haveConfig=
+haveConfig=
+for conf in "${configs[@]}"; do
+	var="RABBITMQ_${conf^^}"
+	val="${!var}"
+	if [ "$val" ]; then
+		haveConfig=1
+		break
+	fi
+done
+
+if [ "$haveConfig" ]; then
+	cat > /etc/rabbitmq/rabbitmq.config <<-'EOH'
+		[
+		  {rabbit,
+		    [
+	EOH
+
+	if [ "$ssl" ]; then
+		cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
+		      { tcp_listeners, [ ] },
+		      { ssl_listeners, [ 5671 ] },
+		      { ssl_options,  [
+		        { certfile,   "$RABBITMQ_SSL_CERT_FILE" },
+		        { keyfile,    "$RABBITMQ_SSL_KEY_FILE" },
+		        { cacertfile, "$RABBITMQ_SSL_CA_FILE" },
+		        { verify,   verify_peer },
+		        { fail_if_no_peer_cert, true } ] },
+		EOS
+	else
+		cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
+		      { tcp_listeners, [ 5672 ] },
+		      { ssl_listeners, [ ] },
+		EOS
+	fi
+
 	for conf in "${configs[@]}"; do
+		[ "${conf#ssl_}" = "$conf" ] || continue
 		var="RABBITMQ_${conf^^}"
 		val="${!var}"
-		if [ "$val" ]; then
-			haveConfig=1
-			break
-		fi
+		[ "$val" ] || continue
+		cat >> /etc/rabbitmq/rabbitmq.config <<-EOC
+		      {$conf, <<"$val">>},
+		EOC
 	done
+	cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
+		      {loopback_users, []}
+	EOF
 
-	if [ "$haveConfig" ]; then
-		cat > /etc/rabbitmq/rabbitmq.config <<-'EOH'
-			[
-			  {rabbit,
-			    [
-		EOH
-		
+	# If management plugin is installed, then generate config consider this
+	if [ "$(rabbitmq-plugins list -m -e rabbitmq_management)" ]; then
+		cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
+			    ]
+			  },
+			  { rabbitmq_management, [
+			      { listener, [
+		EOF
+
 		if [ "$ssl" ]; then
 			cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
-			      { tcp_listeners, [ ] },
-			      { ssl_listeners, [ 5671 ] },
-			      { ssl_options,  [
-			        { certfile,   "$RABBITMQ_SSL_CERT_FILE" },
-			        { keyfile,    "$RABBITMQ_SSL_KEY_FILE" },
-			        { cacertfile, "$RABBITMQ_SSL_CA_FILE" },
-			        { verify,   verify_peer },
-			        { fail_if_no_peer_cert, true } ] },
+			      { port, 15671 },
+			      { ssl, true },
+			      { ssl_opts, [
+			          { certfile,   "$RABBITMQ_SSL_CERT_FILE" },
+			          { keyfile,    "$RABBITMQ_SSL_KEY_FILE" },
+			          { cacertfile, "$RABBITMQ_SSL_CA_FILE" },
+			      { verify,   verify_none },
+			      { fail_if_no_peer_cert, false } ] } ] }
 			EOS
 		else
 			cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
-			      { tcp_listeners, [ 5672 ] },
-			      { ssl_listeners, [ ] },
+			        { port, 15672 },
+			        { ssl, false }
+			        ]
+			      }
 			EOS
 		fi
-		
-		for conf in "${configs[@]}"; do
-			[ "${conf#ssl_}" = "$conf" ] || continue
-			var="RABBITMQ_${conf^^}"
-			val="${!var}"
-			[ "$val" ] || continue
-			cat >> /etc/rabbitmq/rabbitmq.config <<-EOC
-			      {$conf, <<"$val">>},
-			EOC
-		done
-		cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
-			      {loopback_users, []}
-		EOF
-
-		# If management plugin is installed, then generate config consider this
-		if [ "$(rabbitmq-plugins list -m -e rabbitmq_management)" ]; then
-			cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
-				    ]
-				  },
-				  { rabbitmq_management, [
-				      { listener, [
-			EOF
-
-			if [ "$ssl" ]; then
-				cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
-				      { port, 15671 },
-				      { ssl, true },
-				      { ssl_opts, [
-				          { certfile,   "$RABBITMQ_SSL_CERT_FILE" },
-				          { keyfile,    "$RABBITMQ_SSL_KEY_FILE" },
-				          { cacertfile, "$RABBITMQ_SSL_CA_FILE" },
-				      { verify,   verify_none },
-				      { fail_if_no_peer_cert, false } ] } ] }
-				EOS
-			else
-				cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
-				        { port, 15672 },
-				        { ssl, false }
-				        ]
-				      }
-				EOS
-			fi
-		fi
-
-		cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
-			    ]
-			  }
-			].
-		EOF
 	fi
 
-	if [ "$ssl" ]; then
-		# Create combined cert
-		cat "$RABBITMQ_SSL_CERT_FILE" "$RABBITMQ_SSL_KEY_FILE" > /tmp/combined.pem
-		chmod 0400 /tmp/combined.pem
+	cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
+		    ]
+		  }
+		].
+	EOF
+fi
 
-		# More ENV vars for make clustering happiness
-		# we don't handle clustering in this script, but these args should ensure
-		# clustered SSL-enabled members will talk nicely
-		export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
-		export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
-		export RABBITMQ_CTL_ERL_ARGS="$RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS"
-	fi
+if [ "$ssl" ]; then
+	# Create combined cert
+	cat "$RABBITMQ_SSL_CERT_FILE" "$RABBITMQ_SSL_KEY_FILE" > /tmp/combined.pem
+	chmod 0400 /tmp/combined.pem
+
+	# More ENV vars for make clustering happiness
+	# we don't handle clustering in this script, but these args should ensure
+	# clustered SSL-enabled members will talk nicely
+	export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
+	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
+	export RABBITMQ_CTL_ERL_ARGS="$RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS"
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -130,14 +130,17 @@ fi
 
 if [ "$ssl" ]; then
 	# Create combined cert
-	cat "$RABBITMQ_SSL_CERT_FILE" "$RABBITMQ_SSL_KEY_FILE" > /tmp/combined.pem
-	chmod 0400 /tmp/combined.pem
+	# If calling this script with an exec this is problematic, as it needs to be owned 400 for perms but this code can run as root OR rabbitmq.
+	# As a workaround prefix the combined cert with the username so each user only operates on the file they control.
+	combined_file="/tmp/$(id -un)_combined.pem"
+	cat "$RABBITMQ_SSL_CERT_FILE" "$RABBITMQ_SSL_KEY_FILE" > $combined_file
+	chmod 0400 $combined_file
 
 	# More ENV vars for make clustering happiness
 	# we don't handle clustering in this script, but these args should ensure
 	# clustered SSL-enabled members will talk nicely
 	export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
-	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
+	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile $combined_file -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
 	export RABBITMQ_CTL_ERL_ARGS="$RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,112 +31,114 @@ if [ "$RABBITMQ_ERLANG_COOKIE" ]; then
 	fi
 fi
 
-configs=(
-	# https://www.rabbitmq.com/configure.html
-	default_pass
-	default_user
-	default_vhost
-	ssl_ca_file
-	ssl_cert_file
-	ssl_key_file
-)
+if [ "$1" = 'rabbitmq-server' ]; then
+	configs=(
+		# https://www.rabbitmq.com/configure.html
+		default_pass
+		default_user
+		default_vhost
+		ssl_ca_file
+		ssl_cert_file
+		ssl_key_file
+	)
 
-haveConfig=
-for conf in "${configs[@]}"; do
-	var="RABBITMQ_${conf^^}"
-	val="${!var}"
-	if [ "$val" ]; then
-		haveConfig=1
-		break
-	fi
-done
-
-if [ "$haveConfig" ]; then
-	cat > /etc/rabbitmq/rabbitmq.config <<-'EOH'
-		[
-		  {rabbit,
-		    [
-	EOH
-
-	if [ "$ssl" ]; then
-		cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
-		      { tcp_listeners, [ ] },
-		      { ssl_listeners, [ 5671 ] },
-		      { ssl_options,  [
-		        { certfile,   "$RABBITMQ_SSL_CERT_FILE" },
-		        { keyfile,    "$RABBITMQ_SSL_KEY_FILE" },
-		        { cacertfile, "$RABBITMQ_SSL_CA_FILE" },
-		        { verify,   verify_peer },
-		        { fail_if_no_peer_cert, true } ] },
-		EOS
-	else
-		cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
-		      { tcp_listeners, [ 5672 ] },
-		      { ssl_listeners, [ ] },
-		EOS
-	fi
-
+	haveConfig=
 	for conf in "${configs[@]}"; do
-		[ "${conf#ssl_}" = "$conf" ] || continue
 		var="RABBITMQ_${conf^^}"
 		val="${!var}"
-		[ "$val" ] || continue
-		cat >> /etc/rabbitmq/rabbitmq.config <<-EOC
-		      {$conf, <<"$val">>},
-		EOC
+		if [ "$val" ]; then
+			haveConfig=1
+			break
+		fi
 	done
-	cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
-		      {loopback_users, []}
-	EOF
 
-	# If management plugin is installed, then generate config consider this
-	if [ "$(rabbitmq-plugins list -m -e rabbitmq_management)" ]; then
-		cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
-			    ]
-			  },
-			  { rabbitmq_management, [
-			      { listener, [
-		EOF
-
+	if [ "$haveConfig" ]; then
+		cat > /etc/rabbitmq/rabbitmq.config <<-'EOH'
+			[
+			  {rabbit,
+			    [
+		EOH
+		
 		if [ "$ssl" ]; then
 			cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
-			      { port, 15671 },
-			      { ssl, true },
-			      { ssl_opts, [
-			          { certfile,   "$RABBITMQ_SSL_CERT_FILE" },
-			          { keyfile,    "$RABBITMQ_SSL_KEY_FILE" },
-			          { cacertfile, "$RABBITMQ_SSL_CA_FILE" },
-			      { verify,   verify_none },
-			      { fail_if_no_peer_cert, false } ] } ] }
+			      { tcp_listeners, [ ] },
+			      { ssl_listeners, [ 5671 ] },
+			      { ssl_options,  [
+			        { certfile,   "$RABBITMQ_SSL_CERT_FILE" },
+			        { keyfile,    "$RABBITMQ_SSL_KEY_FILE" },
+			        { cacertfile, "$RABBITMQ_SSL_CA_FILE" },
+			        { verify,   verify_peer },
+			        { fail_if_no_peer_cert, true } ] },
 			EOS
 		else
 			cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
-			        { port, 15672 },
-			        { ssl, false }
-			        ]
-			      }
+			      { tcp_listeners, [ 5672 ] },
+			      { ssl_listeners, [ ] },
 			EOS
 		fi
+		
+		for conf in "${configs[@]}"; do
+			[ "${conf#ssl_}" = "$conf" ] || continue
+			var="RABBITMQ_${conf^^}"
+			val="${!var}"
+			[ "$val" ] || continue
+			cat >> /etc/rabbitmq/rabbitmq.config <<-EOC
+			      {$conf, <<"$val">>},
+			EOC
+		done
+		cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
+			      {loopback_users, []}
+		EOF
+
+		# If management plugin is installed, then generate config consider this
+		if [ "$(rabbitmq-plugins list -m -e rabbitmq_management)" ]; then
+			cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
+				    ]
+				  },
+				  { rabbitmq_management, [
+				      { listener, [
+			EOF
+
+			if [ "$ssl" ]; then
+				cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
+				      { port, 15671 },
+				      { ssl, true },
+				      { ssl_opts, [
+				          { certfile,   "$RABBITMQ_SSL_CERT_FILE" },
+				          { keyfile,    "$RABBITMQ_SSL_KEY_FILE" },
+				          { cacertfile, "$RABBITMQ_SSL_CA_FILE" },
+				      { verify,   verify_none },
+				      { fail_if_no_peer_cert, false } ] } ] }
+				EOS
+			else
+				cat >> /etc/rabbitmq/rabbitmq.config <<-EOS
+				        { port, 15672 },
+				        { ssl, false }
+				        ]
+				      }
+				EOS
+			fi
+		fi
+
+		cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
+			    ]
+			  }
+			].
+		EOF
 	fi
 
-	cat >> /etc/rabbitmq/rabbitmq.config <<-'EOF'
-		    ]
-		  }
-		].
-	EOF
-fi
+	if [ "$ssl" ]; then
+		# Create combined cert
+		cat "$RABBITMQ_SSL_CERT_FILE" "$RABBITMQ_SSL_KEY_FILE" > /tmp/combined.pem
+		chmod 0400 /tmp/combined.pem
 
-if [ "$ssl" ]; then
-	# Create combined cert
-	cat "$RABBITMQ_SSL_CERT_FILE" "$RABBITMQ_SSL_KEY_FILE" > /tmp/combined.pem
-	chmod 0400 /tmp/combined.pem
-
-	# More ENV vars for make clustering happiness
-	# we don't handle clustering in this script, but these args should ensure
-	# clustered SSL-enabled members will talk nicely
-	export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
-	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
-	export RABBITMQ_CTL_ERL_ARGS="$RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS"
+		# More ENV vars for make clustering happiness
+		# we don't handle clustering in this script, but these args should ensure
+		# clustered SSL-enabled members will talk nicely
+		export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
+		export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile /tmp/combined.pem -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
+		export RABBITMQ_CTL_ERL_ARGS="$RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS"
+	fi
 fi
 
 exec "$@"


### PR DESCRIPTION
Looking over the history this if appears to have been originally added back in 2014 guarding a chmod on /var/lib/rabbitmq.  Is it still required?  I vote no per the SSL issues I'm seeing in #69, however perhaps someone more familiar with the history fo the script has more insight.

Resolves #69.