### PR TITLE
Use erlang without X11 dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV RABBITMQ_VERSION 3.6.1
 ENV RABBITMQ_DEBIAN_VERSION 3.6.1-1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		erlang erlang-mnesia erlang-public-key erlang-crypto erlang-ssl erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap \
+		erlang-nox erlang-mnesia erlang-public-key erlang-crypto erlang-ssl erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap \
 		rabbitmq-server=$RABBITMQ_DEBIAN_VERSION \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
X11-dependent parts of erlang are in no way needed for rabbitmq, and
getting rid of them reduces installed size of erlang/rabbit from 173 MB
to just 46 MB.