### PR TITLE
Disable SSLv3.0 support to avoid POODLE attack.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -55,6 +55,7 @@ if [ "$1" = 'rabbitmq-server' ]; then
 	if [ "$haveConfig" ]; then
 		cat > /etc/rabbitmq/rabbitmq.config <<-'EOH'
 			[
+			  {ssl, [ { versions, [ 'tlsv1.2', 'tlsv1.1', tlsv1 ] } ]},
 			  {rabbit,
 			    [
 		EOH
@@ -68,6 +69,7 @@ if [ "$1" = 'rabbitmq-server' ]; then
 			        { keyfile,    "$RABBITMQ_SSL_KEY_FILE" },
 			        { cacertfile, "$RABBITMQ_SSL_CA_FILE" },
 			        { verify,   verify_peer },
+			        { versions, [ 'tlsv1.2', 'tlsv1.1', tlsv1 ] },
 			        { fail_if_no_peer_cert, true } ] },
 			EOS
 		else


### PR DESCRIPTION
Disable SSLv3.0 support to avoid POODLE attack. Also, Erlang 18.0 and later does not support SSLv3.0.

Read more: [Enabling SSL Support in RabbitMQ](http://www.rabbitmq.com/ssl.html#enabling-ssl) (Known TLS Vulnerabilities: POODLE, BEAST, etc)