### PR TITLE
update for RabbitMQ version 3.6.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ ENV RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 0A9AF2115F4687BD29803A206B73A36E6026DFCA
 RUN echo 'deb http://www.rabbitmq.com/debian testing main' > /etc/apt/sources.list.d/rabbitmq.list
 
-ENV RABBITMQ_VERSION 3.6.3
-ENV RABBITMQ_DEBIAN_VERSION 3.6.3-1
+ENV RABBITMQ_VERSION 3.6.4
+ENV RABBITMQ_DEBIAN_VERSION 3.6.4-1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		rabbitmq-server=$RABBITMQ_DEBIAN_VERSION \


### PR DESCRIPTION
The RabbitMQ `3.6.4` is out:
https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v3_6_4