### PR TITLE
Fix #102 - ERL_ARGS not exported correctly

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -273,7 +273,7 @@ if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then
 	# we don't handle clustering in this script, but these args should ensure
 	# clustered SSL-enabled members will talk nicely
 	export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
-	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa '$ERL_SSL_PATH' -proto_dist inet_tls -ssl_dist_opt server_certfile '$combinedSsl' -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
+	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-pa $ERL_SSL_PATH -proto_dist inet_tls -ssl_dist_opt server_certfile $combinedSsl -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
 	export RABBITMQ_CTL_ERL_ARGS="$RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS"
 fi
 


### PR DESCRIPTION
With this fix the `rabbitmqctl` command works as expected by using the `docker-entrypoint.sh` wrapper.

```
# docker exec -it rabbit /docker-entrypoint.sh rabbitmqctl list_users
Listing users ...
guest   [administrator]
```
