### PR TITLE
Add "vm_memory_high_watermark" to the generated config, sourced from the value of the "memory.limit_in_bytes" cgroup restriction

### DIFF
--- a/3.6/alpine/Dockerfile
+++ b/3.6/alpine/Dockerfile
@@ -75,7 +75,6 @@ RUN set -ex; \
 ENV HOME /var/lib/rabbitmq
 
 RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq \
-	&& echo '[ { rabbit, [ { loopback_users, [ ] } ] } ].' > /etc/rabbitmq/rabbitmq.config \
 	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq \
 	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq
 VOLUME /var/lib/rabbitmq

--- a/3.6/debian/Dockerfile
+++ b/3.6/debian/Dockerfile
@@ -75,7 +75,6 @@ ENV PATH /usr/lib/rabbitmq/bin:$PATH
 ENV HOME /var/lib/rabbitmq
 
 RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq \
-	&& echo '[ { rabbit, [ { loopback_users, [ ] } ] } ].' > /etc/rabbitmq/rabbitmq.config \
 	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq \
 	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq
 VOLUME /var/lib/rabbitmq


### PR DESCRIPTION
Closes #48

Some example test cases:

``` console
$ docker run -it --rm 842aed1a0ec9
...
Memory limit set to 31616MB of 31616MB total.
...
$ docker run -it --rm -m 100m 842aed1a0ec9
...
Memory limit set to 100MB of 31616MB total.
...
```

I'm not sure if we should be going slightly lower than the available value.

I checked the standard default for this output when `vm_memory_high_watermark` isn't specified, and got the following:

``` console
$ docker run -it --rm rabbitmq
...
Memory limit set to 12646MB of 31616MB total.
...
```

So it looks like the default behavior is actually a fraction of the total available.
