### PR TITLE
Allow for custom definitions file

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -235,8 +235,11 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$haveConfig" ]; then
 
 	fullConfig+=( "{ rabbit, $(rabbit_array "${rabbitConfig[@]}") }" )
 
-	# If management plugin is installed, then generate config consider this
+	# if management plugin is installed, generate config for it
+	# https://www.rabbitmq.com/management.html#configuration
 	if [ "$(rabbitmq-plugins list -m -e rabbitmq_management)" ]; then
+		rabbitManagementConfig=()
+
 		if [ "$haveManagementSslConfig" ]; then
 			IFS=$'\n'
 			rabbitManagementSslOptions=( $(rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}") )
@@ -253,17 +256,22 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$haveConfig" ]; then
 				'{ ssl, false }'
 			)
 		fi
+		rabbitManagementConfig+=(
+			"{ listener, $(rabbit_array "${rabbitManagementListenerConfig[@]}") }"
+		)
 
-		# If definitions file exists, then load it
-		definitions_file=/etc/rabbitmq/definitions.json
-		if [ -f "${definitions_file}" ]; then
-			fullConfig+=(
-				"{ rabbitmq_management, $(rabbit_array "{ listener, $(rabbit_array "${rabbitManagementListenerConfig[@]}") }, { load_definitions, \"${definitions_file}\" }") }"
+		# if definitions file exists, then load it
+		# https://www.rabbitmq.com/management.html#load-definitions
+		managementDefinitionsFile='/etc/rabbitmq/definitions.json'
+		if [ -f "${managementDefinitionsFile}" ]; then
+			# see also https://github.com/docker-library/rabbitmq/pull/112#issuecomment-271485550
+			rabbitManagementConfig+=(
+				"{ load_definitions, \"$managementDefinitionsFile\" }"
 			)
 		fi
 
 		fullConfig+=(
-			"{ rabbitmq_management, $(rabbit_array "{ listener, $(rabbit_array "${rabbitManagementListenerConfig[@]}") }") }"
+			"{ rabbitmq_management, $(rabbit_array "${rabbitManagementConfig[@]}") }"
 		)
 	fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -254,6 +254,14 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$haveConfig" ]; then
 			)
 		fi
 
+		# If definitions file exists, then load it
+		definitions_file=/etc/rabbitmq/definitions.json
+		if [ -f "${definitions_file}" ]; then
+			fullConfig+=(
+				"{ rabbitmq_management, $(rabbit_array "{ listener, $(rabbit_array "${rabbitManagementListenerConfig[@]}") }, { load_definitions, \"${definitions_file}\" }") }"
+			)
+		fi
+
 		fullConfig+=(
 			"{ rabbitmq_management, $(rabbit_array "{ listener, $(rabbit_array "${rabbitManagementListenerConfig[@]}") }") }"
 		)


### PR DESCRIPTION
If a user mounts a definitions file to /etc/rabbitmq/definitons.json, then it will get loaded on startup. Takes care #107 
