### PR TITLE
Add auto cluster support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ script:
   - ~/official-images/test/run.sh "$image"
   - docker build -t "$image:management" management
   - ~/official-images/test/run.sh "$image:management"
+  - docker build -t "$image:rabbitmq-autocluster" rabbitmq-autocluster
+  - ~/official-images/test/run.sh "$image:rabbitmq-autocluster"
 
 after_script:
   - docker images

--- a/rabbitmq-autocluster/Dockerfile
+++ b/rabbitmq-autocluster/Dockerfile
@@ -1,0 +1,11 @@
+FROM rabbitmq:management
+
+
+ENV RABBITMQ_AUTOCLUSTER 0.6.1
+
+RUN  apt-get update -y && apt-get install -y wget && \
+wget -qO- https://github.com/aweber/rabbitmq-autocluster/releases/download/$RABBITMQ_AUTOCLUSTER/autocluster-$RABBITMQ_AUTOCLUSTER.tgz  | tar xvz -C /plugins/ --strip 1 && \
+apt-get purge -y wget
+
+RUN rabbitmq-plugins enable --offline autocluster
+

--- a/rabbitmq-autocluster/README.md
+++ b/rabbitmq-autocluster/README.md
@@ -1,0 +1,6 @@
+Support for RabbitMQ Autocluster
+--
+
+A RabbitMQ plugin that clusters nodes automatically using Consul, etcd2, DNS, AWS EC2 tags or AWS Autoscaling Groups for service discovery.
+
+Read the [official page](https://github.com/aweber/rabbitmq-autocluster) for more details. 


### PR DESCRIPTION
Hi,

This PR adds support for[ RabbitMQ Autocluster](https://github.com/aweber/rabbitmq-autocluster) . 
It supports backends as  etcd and Consul.

Create a cluster is very easy, for example:
```
docker run --name=rabbit1  -e AUTOCLUSTER_TYPE=etcd -e ETCD_HOST=172.18.0.1   -e RABBITMQ_ERLANG_COOKIE='ilovebeam'  rabbitmq-autocluster  

docker run -d --name=rabbit2 --link=rabbit1 -e AUTOCLUSTER_TYPE=etcd -e ETCD_HOST=172.18.0.1 -e RABBITMQ_ERLANG_COOKIE='ilovebeam' rabbitmq-autocluster
```

I think that it is useful for Docker.

What do you think? 