### PR TITLE
Add rabbitmq-clusterer support

### DIFF
--- a/clusterer/Dockerfile
+++ b/clusterer/Dockerfile
@@ -1,0 +1,10 @@
+FROM rabbitmq
+
+ENV RABBITMQ_CLUSTERER_VERSION 1.0.3
+
+RUN set -x \
+        && apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+        && wget -O /usr/lib/rabbitmq/lib/rabbitmq_server-${RABBITMQ_VERSION}/plugins/rabbitmq_clusterer-${RABBITMQ_CLUSTERER_VERSION}.ez https://github.com/rabbitmq/rabbitmq-clusterer/releases/download/v${RABBITMQ_CLUSTERER_VERSION}/rabbitmq_clusterer-${RABBITMQ_CLUSTERER_VERSION}.ez \
+        && apt-get purge -y --auto-remove ca-certificates wget
+
+RUN rabbitmq-plugins enable --offline rabbitmq_clusterer

--- a/update.sh
+++ b/update.sh
@@ -7,6 +7,9 @@ debianVersion="$(curl -sSL 'http://www.rabbitmq.com/debian/dists/testing/main/bi
 
 rabbitmqVersion="${debianVersion%%-*}"
 
+rabbitmqClustererVersion="$(curl -sSL https://github.com/rabbitmq/rabbitmq-clusterer/releases/latest | awk '/<title>Release/ {print substr($2,2)}')"
+
 set -x
 sed -ri 's/^(ENV RABBITMQ_VERSION) .*/\1 '"$rabbitmqVersion"'/' Dockerfile
 sed -ri 's/^(ENV RABBITMQ_DEBIAN_VERSION) .*/\1 '"$debianVersion"'/' Dockerfile
+sed -ri 's/^(ENV RABBITMQ_CLUSTERER_VERSION) .*/\1 '"$rabbitmqClustererVersion"'/' Dockerfile


### PR DESCRIPTION
rabbitmq-clusterer is a plugin created and maintained by the RabbitMQ
team to help facilitate clustering. It will automatically cluster nodes
without the need for the typical "stop_app, join_cluster, start_app"
dance. It can also start a cluster up from a completely stopped start
with no user intervention.