### PR TITLE
Use "/etc/apt/trusted.gpg.d" instead of "apt-key adv"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,13 @@ RUN set -x \
 # See:
 #  - http://www.erlang.org/download.html
 #  - https://www.erlang-solutions.com/resources/download.html
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 434975BD900CCBE4F7EE1B1ED208507CA14F4FCA
+RUN set -ex; \
+	key='434975BD900CCBE4F7EE1B1ED208507CA14F4FCA'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	gpg --export "$key" > /etc/apt/trusted.gpg.d/erlang-solutions.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 RUN echo 'deb http://packages.erlang-solutions.com/debian jessie contrib' > /etc/apt/sources.list.d/erlang.list
 
 # install Erlang
@@ -46,7 +52,13 @@ ENV RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
 
 # http://www.rabbitmq.com/install-debian.html
 # "Please note that the word testing in this line refers to the state of our release of RabbitMQ, not any particular Debian distribution."
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 0A9AF2115F4687BD29803A206B73A36E6026DFCA
+RUN set -ex; \
+	key='0A9AF2115F4687BD29803A206B73A36E6026DFCA'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	gpg --export "$key" > /etc/apt/trusted.gpg.d/rabbitmq.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 RUN echo 'deb http://www.rabbitmq.com/debian testing main' > /etc/apt/sources.list.d/rabbitmq.list
 
 ENV RABBITMQ_VERSION 3.6.6


### PR DESCRIPTION
> Note: Instead of using this command a keyring should be placed
> directly in the /etc/apt/trusted.gpg.d/ directory with a
> descriptive name and either "gpg" or "asc" as file extension.

https://manpages.debian.org/cgi-bin/man.cgi?query=apt-key&manpath=Debian+testing+stretch

See also docker-library/cassandra#91, docker-library/mariadb#93, docker-library/mongo#132, docker-library/mysql#254, docker-library/percona#39, docker-library/postgres#246, docker-library/elasticsearch#152, docker-library/logstash#78, and https://github.com/docker-library/kibana/pull/69.