### PR TITLE
Add proper Architectures entries in "generate-stackbrew-library.sh"

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -37,6 +37,22 @@ dirCommit() {
 	)
 }
 
+getArches() {
+	local repo="$1"; shift
+	local officialImagesUrl='https://github.com/docker-library/official-images/raw/master/library/'
+
+	eval "declare -g -A parentRepoToArches=( $(
+		find -name 'Dockerfile' -exec awk '
+				toupper($1) == "FROM" && $2 !~ /^('"$repo"'|scratch|microsoft\/[^:]+)(:|$)/ {
+					print "'"$officialImagesUrl"'" $2
+				}
+			' '{}' + \
+			| sort -u \
+			| xargs bashbrew cat --format '[{{ .RepoName }}:{{ .TagName }}]="{{ join " " .TagEntry.Architectures }}"'
+	) )"
+}
+getArches 'rabbitmq'
+
 cat <<-EOH
 # this file is generated via https://github.com/docker-library/rabbitmq/blob/$(fileCommit "$self")/$self
 
@@ -75,9 +91,13 @@ for version in "${versions[@]}"; do
 			variantAliases=( "${variantAliases[@]//latest-/}" )
 		fi
 
+		variantParent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/$variant/Dockerfile")"
+		variantArches="${parentRepoToArches[$variantParent]}"
+
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")
+			Architectures: $(join ', ' $variantArches)
 			GitCommit: $commit
 			Directory: $version/$variant
 		EOE
@@ -95,6 +115,7 @@ for version in "${versions[@]}"; do
 			echo
 			cat <<-EOE
 				Tags: $(join ', ' "${subVariantAliases[@]}")
+				Architectures: $(join ', ' $variantArches)
 				GitCommit: $commit
 				Directory: $version/$variant/$subVariant
 			EOE


### PR DESCRIPTION
This depends on https://github.com/docker-library/rabbitmq/pull/166 (since the erlang-solutions repository has a very limited set of architectures supported compared to Debian).

See also docker-library/buildpack-deps#59, docker-library/golang#163, docker-library/docker#63, docker-library/gcc#36, jessfraz/irssi#15, docker-library/redis#95, docker-library/openjdk#121, docker-library/postgres#298, docker-library/haproxy#41, docker-library/httpd#55, docker-library/memcached#19, docker-library/tomcat#73, docker-library/ruby#133, docker-library/python#206, docker-library/php#454, https://github.com/docker-library/wordpress/pull/223.