### PR TITLE
Adjust "erlang-base-hipe" installation to only happen if the package is available

### DIFF
--- a/3.6/debian/Dockerfile
+++ b/3.6/debian/Dockerfile
@@ -26,10 +26,18 @@ RUN set -x \
 	&& apt-get purge -y --auto-remove ca-certificates wget
 
 # install Erlang
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN set -ex; \
+	apt-get update; \
+# "erlang-base-hipe" is optional (and only supported on a few arches)
+# so, only install it if it's available for our current arch
+	if apt-cache show erlang-base-hipe 2>/dev/null | grep -q 'Package: erlang-base-hipe'; then \
+		apt-get install -y --no-install-recommends \
+			erlang-base-hipe \
+		; \
+	fi; \
+# we start with "erlang-base-hipe" because it and "erlang-base" (non-hipe) are exclusive
+	apt-get install -y --no-install-recommends \
 		erlang-asn1 \
-		erlang-base-hipe \
 		erlang-crypto \
 		erlang-eldap \
 		erlang-inets \
@@ -39,7 +47,8 @@ RUN apt-get update \
 		erlang-public-key \
 		erlang-ssl \
 		erlang-xmerl \
-	&& rm -rf /var/lib/apt/lists/*
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 # get logs to stdout (thanks @dumbbell for pushing this upstream! :D)
 ENV RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -94,6 +94,11 @@ for version in "${versions[@]}"; do
 		variantParent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/$variant/Dockerfile")"
 		variantArches="${parentRepoToArches[$variantParent]}"
 
+		if [ "$variant" = 'debian' ]; then
+			# no ppc64le for now: https://www.rabbitmq.com/debian/dists/testing/Release (no "ppc64el" in "Architectures")
+			variantArches="$(echo " $variantArches " | sed -r -e 's/ ppc64le / /g')"
+		fi
+
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")


### PR DESCRIPTION
This also updates "generate-stackbrew-library.sh" to exclude "ppc64le" from the Debian variant given that upstream's repository doesn't have an "Architectures" entry (and supporting files) for it yet.

See https://github.com/docker-library/rabbitmq/pull/167#issuecomment-309817295.

This has been successfully built (and run) on `s390x` (including the not-yet-officially-supported-on-s390x Alpine variant :smile:). :+1:

See also docker-library/buildpack-deps#59, docker-library/golang#163, docker-library/docker#63, docker-library/gcc#36, jessfraz/irssi#15, docker-library/redis#95, docker-library/openjdk#121, docker-library/postgres#298, docker-library/haproxy#41, docker-library/httpd#55, docker-library/memcached#19, docker-library/tomcat#73, docker-library/ruby#133, docker-library/python#206, docker-library/php#454, docker-library/wordpress#223, https://github.com/docker-library/rabbitmq/pull/167.