### PR TITLE
Add arm64v8 since it is now in the rabbitmq apt repo

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -96,8 +96,7 @@ for version in "${versions[@]}"; do
 
 		if [ "$variant" = 'debian' ]; then
 			# no ppc64le for now: https://www.rabbitmq.com/debian/dists/testing/Release (no "ppc64el" in "Architectures")
-			# same with arm64
-			variantArches="$(echo " $variantArches " | sed -r -e 's/ (ppc64le|arm64v[^ ]+)//g')"
+			variantArches="$(echo " $variantArches " | sed -r -e 's/ ppc64le//g')"
 		fi
 
 		echo


### PR DESCRIPTION
See architecture list from https://www.rabbitmq.com/debian/dists/testing/Release
```
Architectures: AVR32 alpha amd64 arm armel armhf arm64 hppa hurd-i386 i386 ia64 kfreebsd-amd64 kfreebsd-i386 m32 m68k mips mipsel netbsd-alpha netbsd-i386 powerpc s390 s390x sh sparc
```

```diff
diff --git a/dev/fd/63 b/dev/fd/62
--- a/dev/fd/63
+++ b/dev/fd/62
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.6.11, 3.6, 3, latest
-Architectures: amd64, arm32v5, arm32v7, i386, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, s390x
 GitCommit: 7d76799247764423a69438f72961ef0581788e07
 Directory: 3.6/debian
 
 Tags: 3.6.11-management, 3.6-management, 3-management, management
-Architectures: amd64, arm32v5, arm32v7, i386, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, s390x
 GitCommit: 79277042564875d55e4b05a60c65b6eb46651a94
 Directory: 3.6/debian/management
```

Fixes #175