### PR TITLE
add RABBITMQ_LOG_LEVELS as a valid env var in docker-entrypoint.sh

### DIFF
--- a/3.6/alpine/docker-entrypoint.sh
+++ b/3.6/alpine/docker-entrypoint.sh
@@ -65,6 +65,7 @@ rabbitConfigKeys=(
 	default_vhost
 	hipe_compile
 	vm_memory_high_watermark
+	log_levels
 )
 fileConfigKeys=(
 	management_ssl_cacertfile
@@ -218,10 +219,15 @@ rabbit_env_config() {
 				rawVal="$val"
 				;;
 
+			log_levels)
+				[ "$val" ] || continue
+				rawVal="[$val]"
+				;;
+
 			hipe_compile)
 				[ "$val" ] && rawVal='true' || rawVal='false'
 				;;
-
+				
 			cacertfile|certfile|keyfile)
 				[ "$val" ] || continue
 				rawVal='"'"$val"'"'

--- a/3.6/debian/docker-entrypoint.sh
+++ b/3.6/debian/docker-entrypoint.sh
@@ -65,6 +65,7 @@ rabbitConfigKeys=(
 	default_vhost
 	hipe_compile
 	vm_memory_high_watermark
+	log_levels
 )
 fileConfigKeys=(
 	management_ssl_cacertfile
@@ -216,6 +217,11 @@ rabbit_env_config() {
 			verify|fail_if_no_peer_cert|depth)
 				[ "$val" ] || continue
 				rawVal="$val"
+				;;
+				
+			log_levels)
+				[ "$val" ] || continue
+				rawVal="[$val]"
 				;;
 
 			hipe_compile)


### PR DESCRIPTION
Allows setting of log levels via environment variable