### PR TITLE
Set chmod 600 on existing cookieFile

### DIFF
--- a/3.6/alpine/docker-entrypoint.sh
+++ b/3.6/alpine/docker-entrypoint.sh
@@ -169,6 +169,10 @@ if [ "${RABBITMQ_ERLANG_COOKIE:-}" ]; then
 			echo >&2 "warning: $cookieFile contents do not match RABBITMQ_ERLANG_COOKIE"
 			echo >&2
 		fi
+		# If we're here, the original container wsa deleted and a new one
+		# was created pointing to the seame mount.
+		# At this point the permission is 777 so we must change it
+		chmod 600 "$cookieFile"
 	else
 		echo "$RABBITMQ_ERLANG_COOKIE" > "$cookieFile"
 		chmod 600 "$cookieFile"

--- a/3.6/alpine/docker-entrypoint.sh
+++ b/3.6/alpine/docker-entrypoint.sh
@@ -169,14 +169,10 @@ if [ "${RABBITMQ_ERLANG_COOKIE:-}" ]; then
 			echo >&2 "warning: $cookieFile contents do not match RABBITMQ_ERLANG_COOKIE"
 			echo >&2
 		fi
-		# If we're here, the original container wsa deleted and a new one
-		# was created pointing to the seame mount.
-		# At this point the permission is 777 so we must change it
-		chmod 600 "$cookieFile"
 	else
 		echo "$RABBITMQ_ERLANG_COOKIE" > "$cookieFile"
-		chmod 600 "$cookieFile"
 	fi
+	chmod 600 "$cookieFile"
 fi
 
 # prints "$2$1$3$1...$N"

--- a/3.6/debian/docker-entrypoint.sh
+++ b/3.6/debian/docker-entrypoint.sh
@@ -171,8 +171,8 @@ if [ "${RABBITMQ_ERLANG_COOKIE:-}" ]; then
 		fi
 	else
 		echo "$RABBITMQ_ERLANG_COOKIE" > "$cookieFile"
-		chmod 600 "$cookieFile"
 	fi
+	chmod 600 "$cookieFile"
 fi
 
 # prints "$2$1$3$1...$N"


### PR DESCRIPTION
Updates the permission of an existing cookie file to the one expected by Erlang.
This allows the image to work with Kubernetes StatefulSets, when a new POD takes the place of a existing one that was deleted.
Whithout it, an ".erlang.cookie must be accessible by owner only" error will occour, once the Dockerfile sets the entire mount permission to 777.