### PR TITLE
[WIP] Add 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: bash
 services: docker
 
 env:
+  - VERSION=3.7 VARIANT=debian
+  - VERSION=3.7 VARIANT=alpine
   - VERSION=3.6 VARIANT=debian
   - VERSION=3.6 VARIANT=alpine
 

--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -1,0 +1,401 @@
+#!/bin/bash
+set -eu
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	if [ "$1" = 'rabbitmq-server' ]; then
+		chown -R rabbitmq /var/lib/rabbitmq
+	fi
+	exec gosu rabbitmq "$BASH_SOURCE" "$@"
+fi
+
+# backwards compatibility for old environment variables
+: "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
+: "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
+: "${RABBITMQ_SSL_CACERTFILE:=${RABBITMQ_SSL_CA_FILE:-}}"
+
+# "management" SSL config should default to using the same certs
+: "${RABBITMQ_MANAGEMENT_SSL_CACERTFILE:=$RABBITMQ_SSL_CACERTFILE}"
+: "${RABBITMQ_MANAGEMENT_SSL_CERTFILE:=$RABBITMQ_SSL_CERTFILE}"
+: "${RABBITMQ_MANAGEMENT_SSL_KEYFILE:=$RABBITMQ_SSL_KEYFILE}"
+
+# Allowed env vars that will be read from mounted files (i.e. Docker Secrets):
+fileEnvKeys=(
+	default_user
+	default_pass
+)
+
+# https://www.rabbitmq.com/configure.html
+sslConfigKeys=(
+	cacertfile
+	certfile
+	depth
+	fail_if_no_peer_cert
+	keyfile
+	verify
+)
+managementConfigKeys=(
+	"${sslConfigKeys[@]/#/ssl_}"
+)
+rabbitConfigKeys=(
+	default_pass
+	default_user
+	default_vhost
+	hipe_compile
+	vm_memory_high_watermark
+)
+fileConfigKeys=(
+	management_ssl_cacertfile
+	management_ssl_certfile
+	management_ssl_keyfile
+	ssl_cacertfile
+	ssl_certfile
+	ssl_keyfile
+)
+allConfigKeys=(
+	"${managementConfigKeys[@]/#/management_}"
+	"${rabbitConfigKeys[@]}"
+	"${sslConfigKeys[@]/#/ssl_}"
+)
+
+declare -A configDefaults=(
+	[management_ssl_fail_if_no_peer_cert]='false'
+	[management_ssl_verify]='verify_none'
+
+	[ssl_fail_if_no_peer_cert]='true'
+	[ssl_verify]='verify_peer'
+)
+
+haveConfig=
+haveSslConfig=
+haveManagementSslConfig=
+for fileEnvKey in "${fileEnvKeys[@]}"; do file_env "RABBITMQ_${fileEnvKey^^}"; done
+for conf in "${allConfigKeys[@]}"; do
+	var="RABBITMQ_${conf^^}"
+	val="${!var:-}"
+	if [ "$val" ]; then
+		if [ "${configDefaults[$conf]:-}" ] && [ "${configDefaults[$conf]}" = "$val" ]; then
+			# if the value set is the same as the default, treat it as if it isn't set
+			continue
+		fi
+		haveConfig=1
+		case "$conf" in
+			ssl_*) haveSslConfig=1 ;;
+			management_ssl_*) haveManagementSslConfig=1 ;;
+		esac
+	fi
+done
+if [ "$haveSslConfig" ]; then
+	missing=()
+	for sslConf in cacertfile certfile keyfile; do
+		var="RABBITMQ_SSL_${sslConf^^}"
+		val="${!var}"
+		if [ -z "$val" ]; then
+			missing+=( "$var" )
+		fi
+	done
+	if [ "${#missing[@]}" -gt 0 ]; then
+		{
+			echo
+			echo 'error: SSL requested, but missing required configuration'
+			for miss in "${missing[@]}"; do
+				echo "  - $miss"
+			done
+			echo
+		} >&2
+		exit 1
+	fi
+fi
+missingFiles=()
+for conf in "${fileConfigKeys[@]}"; do
+	var="RABBITMQ_${conf^^}"
+	val="${!var}"
+	if [ "$val" ] && [ ! -f "$val" ]; then
+		missingFiles+=( "$val ($var)" )
+	fi
+done
+if [ "${#missingFiles[@]}" -gt 0 ]; then
+	{
+		echo
+		echo 'error: files specified, but missing'
+		for miss in "${missingFiles[@]}"; do
+			echo "  - $miss"
+		done
+		echo
+	} >&2
+	exit 1
+fi
+
+# set defaults for missing values (but only after we're done with all our checking so we don't throw any of that off)
+for conf in "${!configDefaults[@]}"; do
+	default="${configDefaults[$conf]}"
+	var="RABBITMQ_${conf^^}"
+	[ -z "${!var:-}" ] || continue
+	eval "export $var=\"\$default\""
+done
+
+# If long & short hostnames are not the same, use long hostnames
+if [ "$(hostname)" != "$(hostname -s)" ]; then
+	: "${RABBITMQ_USE_LONGNAME:=true}"
+fi
+
+if [ "${RABBITMQ_ERLANG_COOKIE:-}" ]; then
+	cookieFile='/var/lib/rabbitmq/.erlang.cookie'
+	if [ -e "$cookieFile" ]; then
+		if [ "$(cat "$cookieFile" 2>/dev/null)" != "$RABBITMQ_ERLANG_COOKIE" ]; then
+			echo >&2
+			echo >&2 "warning: $cookieFile contents do not match RABBITMQ_ERLANG_COOKIE"
+			echo >&2
+		fi
+	else
+		echo "$RABBITMQ_ERLANG_COOKIE" > "$cookieFile"
+	fi
+	chmod 600 "$cookieFile"
+fi
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
+indent() {
+	if [ "$#" -gt 0 ]; then
+		echo "$@"
+	else
+		cat
+	fi | sed 's/^/\t/g'
+}
+rabbit_array() {
+	echo -n '['
+	case "$#" in
+		0) echo -n ' ' ;;
+		1) echo -n " $1 " ;;
+		*)
+			local vals="$(join $',\n' "$@")"
+			echo
+			indent "$vals"
+	esac
+	echo -n ']'
+}
+rabbit_string() {
+	local val="$1"; shift
+	# fire up erlang directly to have it do the proper escaping for us
+	erl -noinput -eval 'io:format("~p\n", init:get_plain_arguments()), init:stop().' -- "$val"
+}
+rabbit_env_config() {
+	local prefix="$1"; shift
+
+	local ret=()
+	local conf
+	for conf; do
+		local var="rabbitmq${prefix:+_$prefix}_$conf"
+		var="${var^^}"
+
+		local val="${!var:-}"
+
+		local rawVal=
+		case "$conf" in
+			verify|fail_if_no_peer_cert|depth)
+				[ "$val" ] || continue
+				rawVal="$val"
+				;;
+
+			hipe_compile)
+				[ "$val" ] && rawVal='true' || rawVal='false'
+				;;
+
+			cacertfile|certfile|keyfile)
+				[ "$val" ] || continue
+				rawVal="$(rabbit_string "$val")"
+				;;
+
+			*)
+				[ "$val" ] || continue
+				rawVal="<<$(rabbit_string "$val")>>"
+				;;
+		esac
+		[ "$rawVal" ] || continue
+
+		ret+=( "{ $conf, $rawVal }" )
+	done
+
+	join $'\n' "${ret[@]}"
+}
+
+shouldWriteConfig="$haveConfig"
+if [ ! -f /etc/rabbitmq/rabbitmq.config ]; then
+	shouldWriteConfig=1
+fi
+
+if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
+	fullConfig=()
+
+	rabbitConfig=(
+		"{ loopback_users, $(rabbit_array) }"
+	)
+
+	# determine whether to set "vm_memory_high_watermark" (based on cgroups)
+	memTotalKb=
+	if [ -r /proc/meminfo ]; then
+		memTotalKb="$(awk -F ':? +' '$1 == "MemTotal" { print $2; exit }' /proc/meminfo)"
+	fi
+	memLimitB=
+	if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+		# "18446744073709551615" is a valid value for "memory.limit_in_bytes", which is too big for Bash math to handle
+		# "$(( 18446744073709551615 / 1024 ))" = 0; "$(( 18446744073709551615 * 40 / 100 ))" = 0
+		memLimitB="$(awk -v totKb="$memTotalKb" '{
+			limB = $0;
+			limKb = limB / 1024;
+			if (!totKb || limKb < totKb) {
+				printf "%.0f\n", limB;
+			}
+		}' /sys/fs/cgroup/memory/memory.limit_in_bytes)"
+	fi
+	if [ -n "$memLimitB" ]; then
+		# if we have a cgroup memory limit, let's inform RabbitMQ of what it is (so it can calculate vm_memory_high_watermark properly)
+		# https://github.com/rabbitmq/rabbitmq-server/pull/1234
+		rabbitConfig+=( "{ total_memory_available_override_value, $memLimitB }" )
+	fi
+	if [ "${RABBITMQ_VM_MEMORY_HIGH_WATERMARK:-}" ]; then
+		# https://github.com/docker-library/rabbitmq/pull/105#issuecomment-242165822
+		vmMemoryHighWatermark="$(
+			awk '
+				/^[0-9]*[.][0-9]+$|^[0-9]+([.][0-9]+)?%$/ {
+					perc = $0;
+					if (perc ~ /%$/) {
+						gsub(/%$/, "", perc);
+						perc = perc / 100;
+					}
+					if (perc > 1.0 || perc <= 0.0) {
+						printf "error: invalid percentage for vm_memory_high_watermark: %s (must be > 0%%, <= 100%%)\n", $0 > "/dev/stderr";
+						exit 1;
+					}
+					printf "%0.03f\n", perc;
+					next;
+				}
+				/^[0-9]+$/ {
+					printf "{ absolute, %s }\n", $0;
+					next;
+				}
+				/^[0-9]+([.][0-9]+)?[a-zA-Z]+$/ {
+					printf "{ absolute, \"%s\" }\n", $0;
+					next;
+				}
+				{
+					printf "error: unexpected input for vm_memory_high_watermark: %s\n", $0;
+					exit 1;
+				}
+			' <(echo "$RABBITMQ_VM_MEMORY_HIGH_WATERMARK")
+		)"
+		if [ "$vmMemoryHighWatermark" ]; then
+			# https://www.rabbitmq.com/memory.html#memsup-usage
+			rabbitConfig+=( "{ vm_memory_high_watermark, $vmMemoryHighWatermark }" )
+		fi
+	fi
+
+	if [ "$haveSslConfig" ]; then
+		IFS=$'\n'
+		rabbitSslOptions=( $(rabbit_env_config 'ssl' "${sslConfigKeys[@]}") )
+		unset IFS
+
+		rabbitConfig+=(
+			"{ tcp_listeners, $(rabbit_array) }"
+			"{ ssl_listeners, $(rabbit_array 5671) }"
+			"{ ssl_options, $(rabbit_array "${rabbitSslOptions[@]}") }"
+		)
+	else
+		rabbitConfig+=(
+			"{ tcp_listeners, $(rabbit_array 5672) }"
+			"{ ssl_listeners, $(rabbit_array) }"
+		)
+	fi
+
+	IFS=$'\n'
+	rabbitConfig+=( $(rabbit_env_config '' "${rabbitConfigKeys[@]}") )
+	unset IFS
+
+	fullConfig+=( "{ rabbit, $(rabbit_array "${rabbitConfig[@]}") }" )
+
+	# if management plugin is installed, generate config for it
+	# https://www.rabbitmq.com/management.html#configuration
+	if [ "$(rabbitmq-plugins list -m -e rabbitmq_management)" ]; then
+		rabbitManagementConfig=()
+
+		if [ "$haveManagementSslConfig" ]; then
+			IFS=$'\n'
+			rabbitManagementSslOptions=( $(rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}") )
+			unset IFS
+
+			rabbitManagementListenerConfig+=(
+				'{ port, 15671 }'
+				'{ ssl, true }'
+				"{ ssl_opts, $(rabbit_array "${rabbitManagementSslOptions[@]}") }"
+			)
+		else
+			rabbitManagementListenerConfig+=(
+				'{ port, 15672 }'
+				'{ ssl, false }'
+			)
+		fi
+		rabbitManagementConfig+=(
+			"{ listener, $(rabbit_array "${rabbitManagementListenerConfig[@]}") }"
+		)
+
+		# if definitions file exists, then load it
+		# https://www.rabbitmq.com/management.html#load-definitions
+		managementDefinitionsFile='/etc/rabbitmq/definitions.json'
+		if [ -f "${managementDefinitionsFile}" ]; then
+			# see also https://github.com/docker-library/rabbitmq/pull/112#issuecomment-271485550
+			rabbitManagementConfig+=(
+				"{ load_definitions, \"$managementDefinitionsFile\" }"
+			)
+		fi
+
+		fullConfig+=(
+			"{ rabbitmq_management, $(rabbit_array "${rabbitManagementConfig[@]}") }"
+		)
+	fi
+
+	echo "$(rabbit_array "${fullConfig[@]}")." > /etc/rabbitmq/rabbitmq.config
+fi
+
+combinedSsl='/tmp/combined.pem'
+if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
+	# Create combined cert
+	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"
+	chmod 0400 "$combinedSsl"
+fi
+if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then
+	# More ENV vars for make clustering happiness
+	# we don't handle clustering in this script, but these args should ensure
+	# clustered SSL-enabled members will talk nicely
+	export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
+	sslErlArgs="-pa $ERL_SSL_PATH -proto_dist inet_tls -ssl_dist_opt server_certfile $combinedSsl -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
+	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="${RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS:-} $sslErlArgs"
+	export RABBITMQ_CTL_ERL_ARGS="${RABBITMQ_CTL_ERL_ARGS:-} $sslErlArgs"
+fi
+
+exec "$@"

--- a/3.7/alpine/Dockerfile
+++ b/3.7/alpine/Dockerfile
@@ -1,0 +1,93 @@
+FROM alpine:3.7
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN addgroup -S rabbitmq && adduser -S -h /var/lib/rabbitmq -G rabbitmq rabbitmq
+
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
+RUN apk add --no-cache \
+# Bash for docker-entrypoint
+		bash \
+# Procps for rabbitmqctl
+		procps \
+# Erlang for RabbitMQ
+		erlang-asn1 \
+		erlang-hipe \
+		erlang-crypto \
+		erlang-eldap \
+		erlang-inets \
+		erlang-mnesia \
+		erlang \
+		erlang-os-mon \
+		erlang-public-key \
+		erlang-sasl \
+		erlang-ssl \
+		erlang-syntax-tools \
+		erlang-xmerl
+
+# get logs to stdout (thanks @dumbbell for pushing this upstream! :D)
+ENV RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
+# https://github.com/rabbitmq/rabbitmq-server/commit/53af45bf9a162dec849407d114041aad3d84feaf
+
+ENV RABBITMQ_HOME /opt/rabbitmq
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
+
+# gpg: key 6026DFCA: public key "RabbitMQ Release Signing Key <info@rabbitmq.com>" imported
+ENV RABBITMQ_GPG_KEY 0A9AF2115F4687BD29803A206B73A36E6026DFCA
+
+ENV RABBITMQ_VERSION 3.7.0
+ENV RABBITMQ_GITHUB_TAG v3.7.0
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		ca-certificates \
+		gnupg \
+		libressl \
+		xz \
+	; \
+	\
+	wget -O rabbitmq-server.tar.xz.asc "https://github.com/rabbitmq/rabbitmq-server/releases/download/$RABBITMQ_GITHUB_TAG/rabbitmq-server-generic-unix-${RABBITMQ_VERSION}.tar.xz.asc"; \
+	wget -O rabbitmq-server.tar.xz     "https://github.com/rabbitmq/rabbitmq-server/releases/download/$RABBITMQ_GITHUB_TAG/rabbitmq-server-generic-unix-${RABBITMQ_VERSION}.tar.xz"; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$RABBITMQ_GPG_KEY"; \
+	gpg --batch --verify rabbitmq-server.tar.xz.asc rabbitmq-server.tar.xz; \
+	rm -rf "$GNUPGHOME"; \
+	\
+	mkdir -p "$RABBITMQ_HOME"; \
+	tar \
+		--extract \
+		--verbose \
+		--file rabbitmq-server.tar.xz \
+		--directory "$RABBITMQ_HOME" \
+		--strip-components 1 \
+	; \
+	rm -f rabbitmq-server.tar.xz*; \
+	\
+# update SYS_PREFIX (first making sure it's set to what we expect it to be)
+	grep -qE '^SYS_PREFIX=\$\{RABBITMQ_HOME\}$' "$RABBITMQ_HOME/sbin/rabbitmq-defaults"; \
+	sed -ri 's!^(SYS_PREFIX=).*$!\1!g' "$RABBITMQ_HOME/sbin/rabbitmq-defaults"; \
+	grep -qE '^SYS_PREFIX=$' "$RABBITMQ_HOME/sbin/rabbitmq-defaults"; \
+	\
+	apk del .build-deps
+
+# set home so that any `--user` knows where to put the erlang cookie
+ENV HOME /var/lib/rabbitmq
+
+RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq \
+	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq \
+	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq
+VOLUME /var/lib/rabbitmq
+
+# add a symlink to the .erlang.cookie in /root so we can "docker exec rabbitmqctl ..." without gosu
+RUN ln -sf /var/lib/rabbitmq/.erlang.cookie /root/
+
+RUN ln -sf "$RABBITMQ_HOME/plugins" /plugins
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 4369 5671 5672 25672
+CMD ["rabbitmq-server"]

--- a/3.7/alpine/docker-entrypoint.sh
+++ b/3.7/alpine/docker-entrypoint.sh
@@ -1,0 +1,401 @@
+#!/bin/bash
+set -eu
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	if [ "$1" = 'rabbitmq-server' ]; then
+		chown -R rabbitmq /var/lib/rabbitmq
+	fi
+	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
+fi
+
+# backwards compatibility for old environment variables
+: "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
+: "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
+: "${RABBITMQ_SSL_CACERTFILE:=${RABBITMQ_SSL_CA_FILE:-}}"
+
+# "management" SSL config should default to using the same certs
+: "${RABBITMQ_MANAGEMENT_SSL_CACERTFILE:=$RABBITMQ_SSL_CACERTFILE}"
+: "${RABBITMQ_MANAGEMENT_SSL_CERTFILE:=$RABBITMQ_SSL_CERTFILE}"
+: "${RABBITMQ_MANAGEMENT_SSL_KEYFILE:=$RABBITMQ_SSL_KEYFILE}"
+
+# Allowed env vars that will be read from mounted files (i.e. Docker Secrets):
+fileEnvKeys=(
+	default_user
+	default_pass
+)
+
+# https://www.rabbitmq.com/configure.html
+sslConfigKeys=(
+	cacertfile
+	certfile
+	depth
+	fail_if_no_peer_cert
+	keyfile
+	verify
+)
+managementConfigKeys=(
+	"${sslConfigKeys[@]/#/ssl_}"
+)
+rabbitConfigKeys=(
+	default_pass
+	default_user
+	default_vhost
+	hipe_compile
+	vm_memory_high_watermark
+)
+fileConfigKeys=(
+	management_ssl_cacertfile
+	management_ssl_certfile
+	management_ssl_keyfile
+	ssl_cacertfile
+	ssl_certfile
+	ssl_keyfile
+)
+allConfigKeys=(
+	"${managementConfigKeys[@]/#/management_}"
+	"${rabbitConfigKeys[@]}"
+	"${sslConfigKeys[@]/#/ssl_}"
+)
+
+declare -A configDefaults=(
+	[management_ssl_fail_if_no_peer_cert]='false'
+	[management_ssl_verify]='verify_none'
+
+	[ssl_fail_if_no_peer_cert]='true'
+	[ssl_verify]='verify_peer'
+)
+
+haveConfig=
+haveSslConfig=
+haveManagementSslConfig=
+for fileEnvKey in "${fileEnvKeys[@]}"; do file_env "RABBITMQ_${fileEnvKey^^}"; done
+for conf in "${allConfigKeys[@]}"; do
+	var="RABBITMQ_${conf^^}"
+	val="${!var:-}"
+	if [ "$val" ]; then
+		if [ "${configDefaults[$conf]:-}" ] && [ "${configDefaults[$conf]}" = "$val" ]; then
+			# if the value set is the same as the default, treat it as if it isn't set
+			continue
+		fi
+		haveConfig=1
+		case "$conf" in
+			ssl_*) haveSslConfig=1 ;;
+			management_ssl_*) haveManagementSslConfig=1 ;;
+		esac
+	fi
+done
+if [ "$haveSslConfig" ]; then
+	missing=()
+	for sslConf in cacertfile certfile keyfile; do
+		var="RABBITMQ_SSL_${sslConf^^}"
+		val="${!var}"
+		if [ -z "$val" ]; then
+			missing+=( "$var" )
+		fi
+	done
+	if [ "${#missing[@]}" -gt 0 ]; then
+		{
+			echo
+			echo 'error: SSL requested, but missing required configuration'
+			for miss in "${missing[@]}"; do
+				echo "  - $miss"
+			done
+			echo
+		} >&2
+		exit 1
+	fi
+fi
+missingFiles=()
+for conf in "${fileConfigKeys[@]}"; do
+	var="RABBITMQ_${conf^^}"
+	val="${!var}"
+	if [ "$val" ] && [ ! -f "$val" ]; then
+		missingFiles+=( "$val ($var)" )
+	fi
+done
+if [ "${#missingFiles[@]}" -gt 0 ]; then
+	{
+		echo
+		echo 'error: files specified, but missing'
+		for miss in "${missingFiles[@]}"; do
+			echo "  - $miss"
+		done
+		echo
+	} >&2
+	exit 1
+fi
+
+# set defaults for missing values (but only after we're done with all our checking so we don't throw any of that off)
+for conf in "${!configDefaults[@]}"; do
+	default="${configDefaults[$conf]}"
+	var="RABBITMQ_${conf^^}"
+	[ -z "${!var:-}" ] || continue
+	eval "export $var=\"\$default\""
+done
+
+# if long and short hostnames are not the same, use long hostnames
+if [ "$(hostname)" != "$(hostname -s)" ]; then
+	: "${RABBITMQ_USE_LONGNAME:=true}"
+fi
+
+if [ "${RABBITMQ_ERLANG_COOKIE:-}" ]; then
+	cookieFile='/var/lib/rabbitmq/.erlang.cookie'
+	if [ -e "$cookieFile" ]; then
+		if [ "$(cat "$cookieFile" 2>/dev/null)" != "$RABBITMQ_ERLANG_COOKIE" ]; then
+			echo >&2
+			echo >&2 "warning: $cookieFile contents do not match RABBITMQ_ERLANG_COOKIE"
+			echo >&2
+		fi
+	else
+		echo "$RABBITMQ_ERLANG_COOKIE" > "$cookieFile"
+	fi
+	chmod 600 "$cookieFile"
+fi
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
+indent() {
+	if [ "$#" -gt 0 ]; then
+		echo "$@"
+	else
+		cat
+	fi | sed 's/^/\t/g'
+}
+rabbit_array() {
+	echo -n '['
+	case "$#" in
+		0) echo -n ' ' ;;
+		1) echo -n " $1 " ;;
+		*)
+			local vals="$(join $',\n' "$@")"
+			echo
+			indent "$vals"
+	esac
+	echo -n ']'
+}
+rabbit_string() {
+	local val="$1"; shift
+	# fire up erlang directly to have it do the proper escaping for us
+	erl -noinput -eval 'io:format("~p\n", init:get_plain_arguments()), init:stop().' -- "$val"
+}
+rabbit_env_config() {
+	local prefix="$1"; shift
+
+	local ret=()
+	local conf
+	for conf; do
+		local var="rabbitmq${prefix:+_$prefix}_$conf"
+		var="${var^^}"
+
+		local val="${!var:-}"
+
+		local rawVal=
+		case "$conf" in
+			verify|fail_if_no_peer_cert|depth)
+				[ "$val" ] || continue
+				rawVal="$val"
+				;;
+
+			hipe_compile)
+				[ "$val" ] && rawVal='true' || rawVal='false'
+				;;
+
+			cacertfile|certfile|keyfile)
+				[ "$val" ] || continue
+				rawVal="$(rabbit_string "$val")"
+				;;
+
+			*)
+				[ "$val" ] || continue
+				rawVal="<<$(rabbit_string "$val")>>"
+				;;
+		esac
+		[ "$rawVal" ] || continue
+
+		ret+=( "{ $conf, $rawVal }" )
+	done
+
+	join $'\n' "${ret[@]}"
+}
+
+shouldWriteConfig="$haveConfig"
+if [ ! -f /etc/rabbitmq/rabbitmq.config ]; then
+	shouldWriteConfig=1
+fi
+
+if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
+	fullConfig=()
+
+	rabbitConfig=(
+		"{ loopback_users, $(rabbit_array) }"
+	)
+
+	# determine whether to set "vm_memory_high_watermark" (based on cgroups)
+	memTotalKb=
+	if [ -r /proc/meminfo ]; then
+		memTotalKb="$(awk -F ':? +' '$1 == "MemTotal" { print $2; exit }' /proc/meminfo)"
+	fi
+	memLimitB=
+	if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+		# "18446744073709551615" is a valid value for "memory.limit_in_bytes", which is too big for Bash math to handle
+		# "$(( 18446744073709551615 / 1024 ))" = 0; "$(( 18446744073709551615 * 40 / 100 ))" = 0
+		memLimitB="$(awk -v totKb="$memTotalKb" '{
+			limB = $0;
+			limKb = limB / 1024;
+			if (!totKb || limKb < totKb) {
+				printf "%.0f\n", limB;
+			}
+		}' /sys/fs/cgroup/memory/memory.limit_in_bytes)"
+	fi
+	if [ -n "$memLimitB" ]; then
+		# if we have a cgroup memory limit, let's inform RabbitMQ of what it is (so it can calculate vm_memory_high_watermark properly)
+		# https://github.com/rabbitmq/rabbitmq-server/pull/1234
+		rabbitConfig+=( "{ total_memory_available_override_value, $memLimitB }" )
+	fi
+	if [ "${RABBITMQ_VM_MEMORY_HIGH_WATERMARK:-}" ]; then
+		# https://github.com/docker-library/rabbitmq/pull/105#issuecomment-242165822
+		vmMemoryHighWatermark="$(
+			awk '
+				/^[0-9]*[.][0-9]+$|^[0-9]+([.][0-9]+)?%$/ {
+					perc = $0;
+					if (perc ~ /%$/) {
+						gsub(/%$/, "", perc);
+						perc = perc / 100;
+					}
+					if (perc > 1.0 || perc <= 0.0) {
+						printf "error: invalid percentage for vm_memory_high_watermark: %s (must be > 0%%, <= 100%%)\n", $0 > "/dev/stderr";
+						exit 1;
+					}
+					printf "%0.03f\n", perc;
+					next;
+				}
+				/^[0-9]+$/ {
+					printf "{ absolute, %s }\n", $0;
+					next;
+				}
+				/^[0-9]+([.][0-9]+)?[a-zA-Z]+$/ {
+					printf "{ absolute, \"%s\" }\n", $0;
+					next;
+				}
+				{
+					printf "error: unexpected input for vm_memory_high_watermark: %s\n", $0;
+					exit 1;
+				}
+			' <(echo "$RABBITMQ_VM_MEMORY_HIGH_WATERMARK")
+		)"
+		if [ "$vmMemoryHighWatermark" ]; then
+			# https://www.rabbitmq.com/memory.html#memsup-usage
+			rabbitConfig+=( "{ vm_memory_high_watermark, $vmMemoryHighWatermark }" )
+		fi
+	fi
+
+	if [ "$haveSslConfig" ]; then
+		IFS=$'\n'
+		rabbitSslOptions=( $(rabbit_env_config 'ssl' "${sslConfigKeys[@]}") )
+		unset IFS
+
+		rabbitConfig+=(
+			"{ tcp_listeners, $(rabbit_array) }"
+			"{ ssl_listeners, $(rabbit_array 5671) }"
+			"{ ssl_options, $(rabbit_array "${rabbitSslOptions[@]}") }"
+		)
+	else
+		rabbitConfig+=(
+			"{ tcp_listeners, $(rabbit_array 5672) }"
+			"{ ssl_listeners, $(rabbit_array) }"
+		)
+	fi
+
+	IFS=$'\n'
+	rabbitConfig+=( $(rabbit_env_config '' "${rabbitConfigKeys[@]}") )
+	unset IFS
+
+	fullConfig+=( "{ rabbit, $(rabbit_array "${rabbitConfig[@]}") }" )
+
+	# if management plugin is installed, generate config for it
+	# https://www.rabbitmq.com/management.html#configuration
+	if [ "$(rabbitmq-plugins list -m -e rabbitmq_management)" ]; then
+		rabbitManagementConfig=()
+
+		if [ "$haveManagementSslConfig" ]; then
+			IFS=$'\n'
+			rabbitManagementSslOptions=( $(rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}") )
+			unset IFS
+
+			rabbitManagementListenerConfig+=(
+				'{ port, 15671 }'
+				'{ ssl, true }'
+				"{ ssl_opts, $(rabbit_array "${rabbitManagementSslOptions[@]}") }"
+			)
+		else
+			rabbitManagementListenerConfig+=(
+				'{ port, 15672 }'
+				'{ ssl, false }'
+			)
+		fi
+		rabbitManagementConfig+=(
+			"{ listener, $(rabbit_array "${rabbitManagementListenerConfig[@]}") }"
+		)
+
+		# if definitions file exists, then load it
+		# https://www.rabbitmq.com/management.html#load-definitions
+		managementDefinitionsFile='/etc/rabbitmq/definitions.json'
+		if [ -f "${managementDefinitionsFile}" ]; then
+			# see also https://github.com/docker-library/rabbitmq/pull/112#issuecomment-271485550
+			rabbitManagementConfig+=(
+				"{ load_definitions, \"$managementDefinitionsFile\" }"
+			)
+		fi
+
+		fullConfig+=(
+			"{ rabbitmq_management, $(rabbit_array "${rabbitManagementConfig[@]}") }"
+		)
+	fi
+
+	echo "$(rabbit_array "${fullConfig[@]}")." > /etc/rabbitmq/rabbitmq.config
+fi
+
+combinedSsl='/tmp/combined.pem'
+if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
+	# Create combined cert
+	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"
+	chmod 0400 "$combinedSsl"
+fi
+if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then
+	# More ENV vars for make clustering happiness
+	# we don't handle clustering in this script, but these args should ensure
+	# clustered SSL-enabled members will talk nicely
+	export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
+	sslErlArgs="-pa $ERL_SSL_PATH -proto_dist inet_tls -ssl_dist_opt server_certfile $combinedSsl -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
+	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="${RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS:-} $sslErlArgs"
+	export RABBITMQ_CTL_ERL_ARGS="${RABBITMQ_CTL_ERL_ARGS:-} $sslErlArgs"
+fi
+
+exec "$@"

--- a/3.7/alpine/management/Dockerfile
+++ b/3.7/alpine/management/Dockerfile
@@ -1,0 +1,5 @@
+FROM rabbitmq:alpine
+
+RUN rabbitmq-plugins enable --offline rabbitmq_management
+
+EXPOSE 15671 15672

--- a/3.7/debian/Dockerfile
+++ b/3.7/debian/Dockerfile
@@ -13,17 +13,52 @@ RUN groupadd -r rabbitmq && useradd -r -d /var/lib/rabbitmq -m -g rabbitmq rabbi
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
-RUN set -eux \
-	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true \
-	&& apt-get purge -y --auto-remove ca-certificates wget
+RUN set -eux; \
+	\
+	fetchDeps=' \
+		ca-certificates \
+		wget \
+	'; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends $fetchDeps; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu nobody true; \
+	\
+	apt-get purge -y --auto-remove $fetchDeps
+
+# RabbitMQ 3.6.15+ requires Erlang 19.3+ (and Stretch only has 19.2); https://www.rabbitmq.com/which-erlang.html
+# so we'll pull Erlang from Buster instead (not using Erlang Solutions since their multiarch support is extremely limited)
+RUN set -eux; \
+# add buster sources.list
+	sed 's/stretch/buster/g' /etc/apt/sources.list \
+		| tee /etc/apt/sources.list.d/buster.list; \
+# update apt-preferences such that we get only erlang* from buster (and erlang* only from buster)
+	{ \
+		echo 'Package: *'; \
+		echo 'Pin: release n=buster*'; \
+		echo 'Pin-Priority: -10'; \
+		echo; \
+		echo 'Package: erlang*'; \
+		echo 'Pin: release n=buster*'; \
+		echo 'Pin-Priority: 999'; \
+		echo; \
+		echo 'Package: erlang*'; \
+		echo 'Pin: release n=stretch*'; \
+		echo 'Pin-Priority: -10'; \
+	} | tee /etc/apt/preferences.d/buster-erlang
 
 # install Erlang
 RUN set -eux; \
@@ -60,9 +95,9 @@ ENV PATH /usr/lib/rabbitmq/bin:$PATH
 # gpg: key 6026DFCA: public key "RabbitMQ Release Signing Key <info@rabbitmq.com>" imported
 ENV RABBITMQ_GPG_KEY 0A9AF2115F4687BD29803A206B73A36E6026DFCA
 
-ENV RABBITMQ_VERSION 3.6.14
-ENV RABBITMQ_GITHUB_TAG rabbitmq_v3_6_14
-ENV RABBITMQ_DEBIAN_VERSION 3.6.14-1
+ENV RABBITMQ_VERSION 3.7.0
+ENV RABBITMQ_GITHUB_TAG v3.7.0
+ENV RABBITMQ_DEBIAN_VERSION 3.7.0-1
 
 RUN set -eux; \
 	\
@@ -84,6 +119,9 @@ RUN set -eux; \
 	rm -f rabbitmq-server.deb*; \
 	\
 	rm -rf /var/lib/apt/lists/*
+
+# warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell)
+ENV LANG C.UTF-8
 
 # set home so that any `--user` knows where to put the erlang cookie
 ENV HOME /var/lib/rabbitmq

--- a/3.7/debian/docker-entrypoint.sh
+++ b/3.7/debian/docker-entrypoint.sh
@@ -1,0 +1,401 @@
+#!/bin/bash
+set -eu
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	if [ "$1" = 'rabbitmq-server' ]; then
+		chown -R rabbitmq /var/lib/rabbitmq
+	fi
+	exec gosu rabbitmq "$BASH_SOURCE" "$@"
+fi
+
+# backwards compatibility for old environment variables
+: "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
+: "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
+: "${RABBITMQ_SSL_CACERTFILE:=${RABBITMQ_SSL_CA_FILE:-}}"
+
+# "management" SSL config should default to using the same certs
+: "${RABBITMQ_MANAGEMENT_SSL_CACERTFILE:=$RABBITMQ_SSL_CACERTFILE}"
+: "${RABBITMQ_MANAGEMENT_SSL_CERTFILE:=$RABBITMQ_SSL_CERTFILE}"
+: "${RABBITMQ_MANAGEMENT_SSL_KEYFILE:=$RABBITMQ_SSL_KEYFILE}"
+
+# Allowed env vars that will be read from mounted files (i.e. Docker Secrets):
+fileEnvKeys=(
+	default_user
+	default_pass
+)
+
+# https://www.rabbitmq.com/configure.html
+sslConfigKeys=(
+	cacertfile
+	certfile
+	depth
+	fail_if_no_peer_cert
+	keyfile
+	verify
+)
+managementConfigKeys=(
+	"${sslConfigKeys[@]/#/ssl_}"
+)
+rabbitConfigKeys=(
+	default_pass
+	default_user
+	default_vhost
+	hipe_compile
+	vm_memory_high_watermark
+)
+fileConfigKeys=(
+	management_ssl_cacertfile
+	management_ssl_certfile
+	management_ssl_keyfile
+	ssl_cacertfile
+	ssl_certfile
+	ssl_keyfile
+)
+allConfigKeys=(
+	"${managementConfigKeys[@]/#/management_}"
+	"${rabbitConfigKeys[@]}"
+	"${sslConfigKeys[@]/#/ssl_}"
+)
+
+declare -A configDefaults=(
+	[management_ssl_fail_if_no_peer_cert]='false'
+	[management_ssl_verify]='verify_none'
+
+	[ssl_fail_if_no_peer_cert]='true'
+	[ssl_verify]='verify_peer'
+)
+
+haveConfig=
+haveSslConfig=
+haveManagementSslConfig=
+for fileEnvKey in "${fileEnvKeys[@]}"; do file_env "RABBITMQ_${fileEnvKey^^}"; done
+for conf in "${allConfigKeys[@]}"; do
+	var="RABBITMQ_${conf^^}"
+	val="${!var:-}"
+	if [ "$val" ]; then
+		if [ "${configDefaults[$conf]:-}" ] && [ "${configDefaults[$conf]}" = "$val" ]; then
+			# if the value set is the same as the default, treat it as if it isn't set
+			continue
+		fi
+		haveConfig=1
+		case "$conf" in
+			ssl_*) haveSslConfig=1 ;;
+			management_ssl_*) haveManagementSslConfig=1 ;;
+		esac
+	fi
+done
+if [ "$haveSslConfig" ]; then
+	missing=()
+	for sslConf in cacertfile certfile keyfile; do
+		var="RABBITMQ_SSL_${sslConf^^}"
+		val="${!var}"
+		if [ -z "$val" ]; then
+			missing+=( "$var" )
+		fi
+	done
+	if [ "${#missing[@]}" -gt 0 ]; then
+		{
+			echo
+			echo 'error: SSL requested, but missing required configuration'
+			for miss in "${missing[@]}"; do
+				echo "  - $miss"
+			done
+			echo
+		} >&2
+		exit 1
+	fi
+fi
+missingFiles=()
+for conf in "${fileConfigKeys[@]}"; do
+	var="RABBITMQ_${conf^^}"
+	val="${!var}"
+	if [ "$val" ] && [ ! -f "$val" ]; then
+		missingFiles+=( "$val ($var)" )
+	fi
+done
+if [ "${#missingFiles[@]}" -gt 0 ]; then
+	{
+		echo
+		echo 'error: files specified, but missing'
+		for miss in "${missingFiles[@]}"; do
+			echo "  - $miss"
+		done
+		echo
+	} >&2
+	exit 1
+fi
+
+# set defaults for missing values (but only after we're done with all our checking so we don't throw any of that off)
+for conf in "${!configDefaults[@]}"; do
+	default="${configDefaults[$conf]}"
+	var="RABBITMQ_${conf^^}"
+	[ -z "${!var:-}" ] || continue
+	eval "export $var=\"\$default\""
+done
+
+# if long and short hostnames are not the same, use long hostnames
+if [ "$(hostname)" != "$(hostname -s)" ]; then
+	: "${RABBITMQ_USE_LONGNAME:=true}"
+fi
+
+if [ "${RABBITMQ_ERLANG_COOKIE:-}" ]; then
+	cookieFile='/var/lib/rabbitmq/.erlang.cookie'
+	if [ -e "$cookieFile" ]; then
+		if [ "$(cat "$cookieFile" 2>/dev/null)" != "$RABBITMQ_ERLANG_COOKIE" ]; then
+			echo >&2
+			echo >&2 "warning: $cookieFile contents do not match RABBITMQ_ERLANG_COOKIE"
+			echo >&2
+		fi
+	else
+		echo "$RABBITMQ_ERLANG_COOKIE" > "$cookieFile"
+	fi
+	chmod 600 "$cookieFile"
+fi
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
+indent() {
+	if [ "$#" -gt 0 ]; then
+		echo "$@"
+	else
+		cat
+	fi | sed 's/^/\t/g'
+}
+rabbit_array() {
+	echo -n '['
+	case "$#" in
+		0) echo -n ' ' ;;
+		1) echo -n " $1 " ;;
+		*)
+			local vals="$(join $',\n' "$@")"
+			echo
+			indent "$vals"
+	esac
+	echo -n ']'
+}
+rabbit_string() {
+	local val="$1"; shift
+	# fire up erlang directly to have it do the proper escaping for us
+	erl -noinput -eval 'io:format("~p\n", init:get_plain_arguments()), init:stop().' -- "$val"
+}
+rabbit_env_config() {
+	local prefix="$1"; shift
+
+	local ret=()
+	local conf
+	for conf; do
+		local var="rabbitmq${prefix:+_$prefix}_$conf"
+		var="${var^^}"
+
+		local val="${!var:-}"
+
+		local rawVal=
+		case "$conf" in
+			verify|fail_if_no_peer_cert|depth)
+				[ "$val" ] || continue
+				rawVal="$val"
+				;;
+
+			hipe_compile)
+				[ "$val" ] && rawVal='true' || rawVal='false'
+				;;
+
+			cacertfile|certfile|keyfile)
+				[ "$val" ] || continue
+				rawVal="$(rabbit_string "$val")"
+				;;
+
+			*)
+				[ "$val" ] || continue
+				rawVal="<<$(rabbit_string "$val")>>"
+				;;
+		esac
+		[ "$rawVal" ] || continue
+
+		ret+=( "{ $conf, $rawVal }" )
+	done
+
+	join $'\n' "${ret[@]}"
+}
+
+shouldWriteConfig="$haveConfig"
+if [ ! -f /etc/rabbitmq/rabbitmq.config ]; then
+	shouldWriteConfig=1
+fi
+
+if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
+	fullConfig=()
+
+	rabbitConfig=(
+		"{ loopback_users, $(rabbit_array) }"
+	)
+
+	# determine whether to set "vm_memory_high_watermark" (based on cgroups)
+	memTotalKb=
+	if [ -r /proc/meminfo ]; then
+		memTotalKb="$(awk -F ':? +' '$1 == "MemTotal" { print $2; exit }' /proc/meminfo)"
+	fi
+	memLimitB=
+	if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+		# "18446744073709551615" is a valid value for "memory.limit_in_bytes", which is too big for Bash math to handle
+		# "$(( 18446744073709551615 / 1024 ))" = 0; "$(( 18446744073709551615 * 40 / 100 ))" = 0
+		memLimitB="$(awk -v totKb="$memTotalKb" '{
+			limB = $0;
+			limKb = limB / 1024;
+			if (!totKb || limKb < totKb) {
+				printf "%.0f\n", limB;
+			}
+		}' /sys/fs/cgroup/memory/memory.limit_in_bytes)"
+	fi
+	if [ -n "$memLimitB" ]; then
+		# if we have a cgroup memory limit, let's inform RabbitMQ of what it is (so it can calculate vm_memory_high_watermark properly)
+		# https://github.com/rabbitmq/rabbitmq-server/pull/1234
+		rabbitConfig+=( "{ total_memory_available_override_value, $memLimitB }" )
+	fi
+	if [ "${RABBITMQ_VM_MEMORY_HIGH_WATERMARK:-}" ]; then
+		# https://github.com/docker-library/rabbitmq/pull/105#issuecomment-242165822
+		vmMemoryHighWatermark="$(
+			awk '
+				/^[0-9]*[.][0-9]+$|^[0-9]+([.][0-9]+)?%$/ {
+					perc = $0;
+					if (perc ~ /%$/) {
+						gsub(/%$/, "", perc);
+						perc = perc / 100;
+					}
+					if (perc > 1.0 || perc <= 0.0) {
+						printf "error: invalid percentage for vm_memory_high_watermark: %s (must be > 0%%, <= 100%%)\n", $0 > "/dev/stderr";
+						exit 1;
+					}
+					printf "%0.03f\n", perc;
+					next;
+				}
+				/^[0-9]+$/ {
+					printf "{ absolute, %s }\n", $0;
+					next;
+				}
+				/^[0-9]+([.][0-9]+)?[a-zA-Z]+$/ {
+					printf "{ absolute, \"%s\" }\n", $0;
+					next;
+				}
+				{
+					printf "error: unexpected input for vm_memory_high_watermark: %s\n", $0;
+					exit 1;
+				}
+			' <(echo "$RABBITMQ_VM_MEMORY_HIGH_WATERMARK")
+		)"
+		if [ "$vmMemoryHighWatermark" ]; then
+			# https://www.rabbitmq.com/memory.html#memsup-usage
+			rabbitConfig+=( "{ vm_memory_high_watermark, $vmMemoryHighWatermark }" )
+		fi
+	fi
+
+	if [ "$haveSslConfig" ]; then
+		IFS=$'\n'
+		rabbitSslOptions=( $(rabbit_env_config 'ssl' "${sslConfigKeys[@]}") )
+		unset IFS
+
+		rabbitConfig+=(
+			"{ tcp_listeners, $(rabbit_array) }"
+			"{ ssl_listeners, $(rabbit_array 5671) }"
+			"{ ssl_options, $(rabbit_array "${rabbitSslOptions[@]}") }"
+		)
+	else
+		rabbitConfig+=(
+			"{ tcp_listeners, $(rabbit_array 5672) }"
+			"{ ssl_listeners, $(rabbit_array) }"
+		)
+	fi
+
+	IFS=$'\n'
+	rabbitConfig+=( $(rabbit_env_config '' "${rabbitConfigKeys[@]}") )
+	unset IFS
+
+	fullConfig+=( "{ rabbit, $(rabbit_array "${rabbitConfig[@]}") }" )
+
+	# if management plugin is installed, generate config for it
+	# https://www.rabbitmq.com/management.html#configuration
+	if [ "$(rabbitmq-plugins list -m -e rabbitmq_management)" ]; then
+		rabbitManagementConfig=()
+
+		if [ "$haveManagementSslConfig" ]; then
+			IFS=$'\n'
+			rabbitManagementSslOptions=( $(rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}") )
+			unset IFS
+
+			rabbitManagementListenerConfig+=(
+				'{ port, 15671 }'
+				'{ ssl, true }'
+				"{ ssl_opts, $(rabbit_array "${rabbitManagementSslOptions[@]}") }"
+			)
+		else
+			rabbitManagementListenerConfig+=(
+				'{ port, 15672 }'
+				'{ ssl, false }'
+			)
+		fi
+		rabbitManagementConfig+=(
+			"{ listener, $(rabbit_array "${rabbitManagementListenerConfig[@]}") }"
+		)
+
+		# if definitions file exists, then load it
+		# https://www.rabbitmq.com/management.html#load-definitions
+		managementDefinitionsFile='/etc/rabbitmq/definitions.json'
+		if [ -f "${managementDefinitionsFile}" ]; then
+			# see also https://github.com/docker-library/rabbitmq/pull/112#issuecomment-271485550
+			rabbitManagementConfig+=(
+				"{ load_definitions, \"$managementDefinitionsFile\" }"
+			)
+		fi
+
+		fullConfig+=(
+			"{ rabbitmq_management, $(rabbit_array "${rabbitManagementConfig[@]}") }"
+		)
+	fi
+
+	echo "$(rabbit_array "${fullConfig[@]}")." > /etc/rabbitmq/rabbitmq.config
+fi
+
+combinedSsl='/tmp/combined.pem'
+if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
+	# Create combined cert
+	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"
+	chmod 0400 "$combinedSsl"
+fi
+if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then
+	# More ENV vars for make clustering happiness
+	# we don't handle clustering in this script, but these args should ensure
+	# clustered SSL-enabled members will talk nicely
+	export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
+	sslErlArgs="-pa $ERL_SSL_PATH -proto_dist inet_tls -ssl_dist_opt server_certfile $combinedSsl -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
+	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="${RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS:-} $sslErlArgs"
+	export RABBITMQ_CTL_ERL_ARGS="${RABBITMQ_CTL_ERL_ARGS:-} $sslErlArgs"
+fi
+
+exec "$@"

--- a/3.7/debian/management/Dockerfile
+++ b/3.7/debian/management/Dockerfile
@@ -1,0 +1,5 @@
+FROM rabbitmq
+
+RUN rabbitmq-plugins enable --offline rabbitmq_management
+
+EXPOSE 15671 15672

--- a/3.7/docker-entrypoint.sh
+++ b/3.7/docker-entrypoint.sh
@@ -1,0 +1,401 @@
+#!/bin/bash
+set -eu
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	if [ "$1" = 'rabbitmq-server' ]; then
+		chown -R rabbitmq /var/lib/rabbitmq
+	fi
+	exec gosu rabbitmq "$BASH_SOURCE" "$@"
+fi
+
+# backwards compatibility for old environment variables
+: "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
+: "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
+: "${RABBITMQ_SSL_CACERTFILE:=${RABBITMQ_SSL_CA_FILE:-}}"
+
+# "management" SSL config should default to using the same certs
+: "${RABBITMQ_MANAGEMENT_SSL_CACERTFILE:=$RABBITMQ_SSL_CACERTFILE}"
+: "${RABBITMQ_MANAGEMENT_SSL_CERTFILE:=$RABBITMQ_SSL_CERTFILE}"
+: "${RABBITMQ_MANAGEMENT_SSL_KEYFILE:=$RABBITMQ_SSL_KEYFILE}"
+
+# Allowed env vars that will be read from mounted files (i.e. Docker Secrets):
+fileEnvKeys=(
+	default_user
+	default_pass
+)
+
+# https://www.rabbitmq.com/configure.html
+sslConfigKeys=(
+	cacertfile
+	certfile
+	depth
+	fail_if_no_peer_cert
+	keyfile
+	verify
+)
+managementConfigKeys=(
+	"${sslConfigKeys[@]/#/ssl_}"
+)
+rabbitConfigKeys=(
+	default_pass
+	default_user
+	default_vhost
+	hipe_compile
+	vm_memory_high_watermark
+)
+fileConfigKeys=(
+	management_ssl_cacertfile
+	management_ssl_certfile
+	management_ssl_keyfile
+	ssl_cacertfile
+	ssl_certfile
+	ssl_keyfile
+)
+allConfigKeys=(
+	"${managementConfigKeys[@]/#/management_}"
+	"${rabbitConfigKeys[@]}"
+	"${sslConfigKeys[@]/#/ssl_}"
+)
+
+declare -A configDefaults=(
+	[management_ssl_fail_if_no_peer_cert]='false'
+	[management_ssl_verify]='verify_none'
+
+	[ssl_fail_if_no_peer_cert]='true'
+	[ssl_verify]='verify_peer'
+)
+
+haveConfig=
+haveSslConfig=
+haveManagementSslConfig=
+for fileEnvKey in "${fileEnvKeys[@]}"; do file_env "RABBITMQ_${fileEnvKey^^}"; done
+for conf in "${allConfigKeys[@]}"; do
+	var="RABBITMQ_${conf^^}"
+	val="${!var:-}"
+	if [ "$val" ]; then
+		if [ "${configDefaults[$conf]:-}" ] && [ "${configDefaults[$conf]}" = "$val" ]; then
+			# if the value set is the same as the default, treat it as if it isn't set
+			continue
+		fi
+		haveConfig=1
+		case "$conf" in
+			ssl_*) haveSslConfig=1 ;;
+			management_ssl_*) haveManagementSslConfig=1 ;;
+		esac
+	fi
+done
+if [ "$haveSslConfig" ]; then
+	missing=()
+	for sslConf in cacertfile certfile keyfile; do
+		var="RABBITMQ_SSL_${sslConf^^}"
+		val="${!var}"
+		if [ -z "$val" ]; then
+			missing+=( "$var" )
+		fi
+	done
+	if [ "${#missing[@]}" -gt 0 ]; then
+		{
+			echo
+			echo 'error: SSL requested, but missing required configuration'
+			for miss in "${missing[@]}"; do
+				echo "  - $miss"
+			done
+			echo
+		} >&2
+		exit 1
+	fi
+fi
+missingFiles=()
+for conf in "${fileConfigKeys[@]}"; do
+	var="RABBITMQ_${conf^^}"
+	val="${!var}"
+	if [ "$val" ] && [ ! -f "$val" ]; then
+		missingFiles+=( "$val ($var)" )
+	fi
+done
+if [ "${#missingFiles[@]}" -gt 0 ]; then
+	{
+		echo
+		echo 'error: files specified, but missing'
+		for miss in "${missingFiles[@]}"; do
+			echo "  - $miss"
+		done
+		echo
+	} >&2
+	exit 1
+fi
+
+# set defaults for missing values (but only after we're done with all our checking so we don't throw any of that off)
+for conf in "${!configDefaults[@]}"; do
+	default="${configDefaults[$conf]}"
+	var="RABBITMQ_${conf^^}"
+	[ -z "${!var:-}" ] || continue
+	eval "export $var=\"\$default\""
+done
+
+# if long and short hostnames are not the same, use long hostnames
+if [ "$(hostname)" != "$(hostname -s)" ]; then
+	: "${RABBITMQ_USE_LONGNAME:=true}"
+fi
+
+if [ "${RABBITMQ_ERLANG_COOKIE:-}" ]; then
+	cookieFile='/var/lib/rabbitmq/.erlang.cookie'
+	if [ -e "$cookieFile" ]; then
+		if [ "$(cat "$cookieFile" 2>/dev/null)" != "$RABBITMQ_ERLANG_COOKIE" ]; then
+			echo >&2
+			echo >&2 "warning: $cookieFile contents do not match RABBITMQ_ERLANG_COOKIE"
+			echo >&2
+		fi
+	else
+		echo "$RABBITMQ_ERLANG_COOKIE" > "$cookieFile"
+	fi
+	chmod 600 "$cookieFile"
+fi
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
+indent() {
+	if [ "$#" -gt 0 ]; then
+		echo "$@"
+	else
+		cat
+	fi | sed 's/^/\t/g'
+}
+rabbit_array() {
+	echo -n '['
+	case "$#" in
+		0) echo -n ' ' ;;
+		1) echo -n " $1 " ;;
+		*)
+			local vals="$(join $',\n' "$@")"
+			echo
+			indent "$vals"
+	esac
+	echo -n ']'
+}
+rabbit_string() {
+	local val="$1"; shift
+	# fire up erlang directly to have it do the proper escaping for us
+	erl -noinput -eval 'io:format("~p\n", init:get_plain_arguments()), init:stop().' -- "$val"
+}
+rabbit_env_config() {
+	local prefix="$1"; shift
+
+	local ret=()
+	local conf
+	for conf; do
+		local var="rabbitmq${prefix:+_$prefix}_$conf"
+		var="${var^^}"
+
+		local val="${!var:-}"
+
+		local rawVal=
+		case "$conf" in
+			verify|fail_if_no_peer_cert|depth)
+				[ "$val" ] || continue
+				rawVal="$val"
+				;;
+
+			hipe_compile)
+				[ "$val" ] && rawVal='true' || rawVal='false'
+				;;
+
+			cacertfile|certfile|keyfile)
+				[ "$val" ] || continue
+				rawVal="$(rabbit_string "$val")"
+				;;
+
+			*)
+				[ "$val" ] || continue
+				rawVal="<<$(rabbit_string "$val")>>"
+				;;
+		esac
+		[ "$rawVal" ] || continue
+
+		ret+=( "{ $conf, $rawVal }" )
+	done
+
+	join $'\n' "${ret[@]}"
+}
+
+shouldWriteConfig="$haveConfig"
+if [ ! -f /etc/rabbitmq/rabbitmq.config ]; then
+	shouldWriteConfig=1
+fi
+
+if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
+	fullConfig=()
+
+	rabbitConfig=(
+		"{ loopback_users, $(rabbit_array) }"
+	)
+
+	# determine whether to set "vm_memory_high_watermark" (based on cgroups)
+	memTotalKb=
+	if [ -r /proc/meminfo ]; then
+		memTotalKb="$(awk -F ':? +' '$1 == "MemTotal" { print $2; exit }' /proc/meminfo)"
+	fi
+	memLimitB=
+	if [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+		# "18446744073709551615" is a valid value for "memory.limit_in_bytes", which is too big for Bash math to handle
+		# "$(( 18446744073709551615 / 1024 ))" = 0; "$(( 18446744073709551615 * 40 / 100 ))" = 0
+		memLimitB="$(awk -v totKb="$memTotalKb" '{
+			limB = $0;
+			limKb = limB / 1024;
+			if (!totKb || limKb < totKb) {
+				printf "%.0f\n", limB;
+			}
+		}' /sys/fs/cgroup/memory/memory.limit_in_bytes)"
+	fi
+	if [ -n "$memLimitB" ]; then
+		# if we have a cgroup memory limit, let's inform RabbitMQ of what it is (so it can calculate vm_memory_high_watermark properly)
+		# https://github.com/rabbitmq/rabbitmq-server/pull/1234
+		rabbitConfig+=( "{ total_memory_available_override_value, $memLimitB }" )
+	fi
+	if [ "${RABBITMQ_VM_MEMORY_HIGH_WATERMARK:-}" ]; then
+		# https://github.com/docker-library/rabbitmq/pull/105#issuecomment-242165822
+		vmMemoryHighWatermark="$(
+			awk '
+				/^[0-9]*[.][0-9]+$|^[0-9]+([.][0-9]+)?%$/ {
+					perc = $0;
+					if (perc ~ /%$/) {
+						gsub(/%$/, "", perc);
+						perc = perc / 100;
+					}
+					if (perc > 1.0 || perc <= 0.0) {
+						printf "error: invalid percentage for vm_memory_high_watermark: %s (must be > 0%%, <= 100%%)\n", $0 > "/dev/stderr";
+						exit 1;
+					}
+					printf "%0.03f\n", perc;
+					next;
+				}
+				/^[0-9]+$/ {
+					printf "{ absolute, %s }\n", $0;
+					next;
+				}
+				/^[0-9]+([.][0-9]+)?[a-zA-Z]+$/ {
+					printf "{ absolute, \"%s\" }\n", $0;
+					next;
+				}
+				{
+					printf "error: unexpected input for vm_memory_high_watermark: %s\n", $0;
+					exit 1;
+				}
+			' <(echo "$RABBITMQ_VM_MEMORY_HIGH_WATERMARK")
+		)"
+		if [ "$vmMemoryHighWatermark" ]; then
+			# https://www.rabbitmq.com/memory.html#memsup-usage
+			rabbitConfig+=( "{ vm_memory_high_watermark, $vmMemoryHighWatermark }" )
+		fi
+	fi
+
+	if [ "$haveSslConfig" ]; then
+		IFS=$'\n'
+		rabbitSslOptions=( $(rabbit_env_config 'ssl' "${sslConfigKeys[@]}") )
+		unset IFS
+
+		rabbitConfig+=(
+			"{ tcp_listeners, $(rabbit_array) }"
+			"{ ssl_listeners, $(rabbit_array 5671) }"
+			"{ ssl_options, $(rabbit_array "${rabbitSslOptions[@]}") }"
+		)
+	else
+		rabbitConfig+=(
+			"{ tcp_listeners, $(rabbit_array 5672) }"
+			"{ ssl_listeners, $(rabbit_array) }"
+		)
+	fi
+
+	IFS=$'\n'
+	rabbitConfig+=( $(rabbit_env_config '' "${rabbitConfigKeys[@]}") )
+	unset IFS
+
+	fullConfig+=( "{ rabbit, $(rabbit_array "${rabbitConfig[@]}") }" )
+
+	# if management plugin is installed, generate config for it
+	# https://www.rabbitmq.com/management.html#configuration
+	if [ "$(rabbitmq-plugins list -m -e rabbitmq_management)" ]; then
+		rabbitManagementConfig=()
+
+		if [ "$haveManagementSslConfig" ]; then
+			IFS=$'\n'
+			rabbitManagementSslOptions=( $(rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}") )
+			unset IFS
+
+			rabbitManagementListenerConfig+=(
+				'{ port, 15671 }'
+				'{ ssl, true }'
+				"{ ssl_opts, $(rabbit_array "${rabbitManagementSslOptions[@]}") }"
+			)
+		else
+			rabbitManagementListenerConfig+=(
+				'{ port, 15672 }'
+				'{ ssl, false }'
+			)
+		fi
+		rabbitManagementConfig+=(
+			"{ listener, $(rabbit_array "${rabbitManagementListenerConfig[@]}") }"
+		)
+
+		# if definitions file exists, then load it
+		# https://www.rabbitmq.com/management.html#load-definitions
+		managementDefinitionsFile='/etc/rabbitmq/definitions.json'
+		if [ -f "${managementDefinitionsFile}" ]; then
+			# see also https://github.com/docker-library/rabbitmq/pull/112#issuecomment-271485550
+			rabbitManagementConfig+=(
+				"{ load_definitions, \"$managementDefinitionsFile\" }"
+			)
+		fi
+
+		fullConfig+=(
+			"{ rabbitmq_management, $(rabbit_array "${rabbitManagementConfig[@]}") }"
+		)
+	fi
+
+	echo "$(rabbit_array "${fullConfig[@]}")." > /etc/rabbitmq/rabbitmq.config
+fi
+
+combinedSsl='/tmp/combined.pem'
+if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
+	# Create combined cert
+	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"
+	chmod 0400 "$combinedSsl"
+fi
+if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then
+	# More ENV vars for make clustering happiness
+	# we don't handle clustering in this script, but these args should ensure
+	# clustered SSL-enabled members will talk nicely
+	export ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
+	sslErlArgs="-pa $ERL_SSL_PATH -proto_dist inet_tls -ssl_dist_opt server_certfile $combinedSsl -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
+	export RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="${RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS:-} $sslErlArgs"
+	export RABBITMQ_CTL_ERL_ARGS="${RABBITMQ_CTL_ERL_ARGS:-} $sslErlArgs"
+fi
+
+exec "$@"

--- a/update.sh
+++ b/update.sh
@@ -58,7 +58,11 @@ for version in "${versions[@]}"; do
 				-e 's/^(ENV RABBITMQ_GITHUB_TAG) .*/\1 '"$githubTag"'/' \
 				-e 's/^(ENV RABBITMQ_DEBIAN_VERSION) .*/\1 '"$debianVersion"'/' \
 				"$version/$variant/Dockerfile"
+			cp -va "$version/docker-entrypoint.sh" "$version/$variant/"
 		)
+		if [ "$variant" = 'alpine' ]; then
+			sed -i 's/gosu/su-exec/g' "$version/$variant/docker-entrypoint.sh"
+		fi
 
 		travisEnv='\n  - VERSION='"$version"' VARIANT='"$variant$travisEnv"
 	done


### PR DESCRIPTION
Closes #183

This builds on https://github.com/docker-library/rabbitmq/pull/195 to start implementing support for 3.7.  I haven't converted the entrypoint to use `rabbitmq.conf` yet, but I've looked at a lot of the documentation and am really pleased with how nice and simple everything looks. :smile:

I'm casually pondering (as noted in https://github.com/docker-library/rabbitmq/pull/187#issuecomment-331958473) whether we should use this major version bump as an opportunity to claw back our supported environment variables to something closer to what upstream natively supports out-of-the-box, but would appreciate if @michaelklishin (or anyone else from upstream) would be willing to provide some color on whether that's something we definitely should try do, definitely should not do, or something upstream is likely to be indifferent about. :pray:

It's definitely easier in Docker to provide environment variables than it is to provide a whole new config file, although only really for the one-off use case -- for a real production deployment, the difference is pretty negligible.

There's also the new auto-clustering behavior proposed in #183 that we ought to consider supporting somehow (which if we stick with environment variables will mean new ones to configure that, but if we ditch the environment variables will likely mean a total punt on any additional behavior to support that out-of-the-box due to strictly bring-your-own configuration).