### PR TITLE
Pass string values through "erl" for appropriate escaping

### DIFF
--- a/3.6/alpine/docker-entrypoint.sh
+++ b/3.6/alpine/docker-entrypoint.sh
@@ -200,6 +200,11 @@ rabbit_array() {
 	esac
 	echo -n ']'
 }
+rabbit_string() {
+	local val="$1"; shift
+	# fire up erlang directly to have it do the proper escaping for us
+	erl -noinput -eval 'io:format("~p\n", init:get_plain_arguments()), init:stop().' -- "$val"
+}
 rabbit_env_config() {
 	local prefix="$1"; shift
 
@@ -224,12 +229,12 @@ rabbit_env_config() {
 
 			cacertfile|certfile|keyfile)
 				[ "$val" ] || continue
-				rawVal='"'"$val"'"'
+				rawVal="$(rabbit_string "$val")"
 				;;
 
 			*)
 				[ "$val" ] || continue
-				rawVal='<<"'"$val"'">>'
+				rawVal="<<$(rabbit_string "$val")>>"
 				;;
 		esac
 		[ "$rawVal" ] || continue

--- a/3.6/debian/docker-entrypoint.sh
+++ b/3.6/debian/docker-entrypoint.sh
@@ -200,6 +200,11 @@ rabbit_array() {
 	esac
 	echo -n ']'
 }
+rabbit_string() {
+	local val="$1"; shift
+	# fire up erlang directly to have it do the proper escaping for us
+	erl -noinput -eval 'io:format("~p\n", init:get_plain_arguments()), init:stop().' -- "$val"
+}
 rabbit_env_config() {
 	local prefix="$1"; shift
 
@@ -224,12 +229,12 @@ rabbit_env_config() {
 
 			cacertfile|certfile|keyfile)
 				[ "$val" ] || continue
-				rawVal='"'"$val"'"'
+				rawVal="$(rabbit_string "$val")"
 				;;
 
 			*)
 				[ "$val" ] || continue
-				rawVal='<<"'"$val"'">>'
+				rawVal="<<$(rabbit_string "$val")>>"
 				;;
 		esac
 		[ "$rawVal" ] || continue


### PR DESCRIPTION
This is roughly equivalent to using `var_export` in PHP. :smile:  The end result of this simple `erl` one-liner is that it takes a single argument and returns a copy of it safely Erlang-quoted:

```console
root@7ef63acdb2cd:/# erl -noinput -eval 'io:format("~p\n", init:get_plain_arguments()), init:stop().' -- $'a\nb\tc\t"\t\nd'
"a\nb\tc\t\"\t\nd"
```

Closes #199

I've verified that the result of `RABBITMQ_DEFAULT_PASS=$'a\nb\nc'` becomes `{ default_pass, <<"a\nb\nc">> }`, as expected (and RabbitMQ starts up successfully).  I'm not sure whether newlines in a password actually makes any sense, but it might for other values, and this insulates us completely against needing to worry about specific characters or validation.