### PR TITLE
Add support for heartbeat parameter

### DIFF
--- a/3.6/alpine/docker-entrypoint.sh
+++ b/3.6/alpine/docker-entrypoint.sh
@@ -63,6 +63,7 @@ rabbitConfigKeys=(
 	default_pass
 	default_user
 	default_vhost
+	heartbeat
 	hipe_compile
 	vm_memory_high_watermark
 )
@@ -218,7 +219,7 @@ rabbit_env_config() {
 
 		local rawVal=
 		case "$conf" in
-			verify|fail_if_no_peer_cert|depth)
+			verify|fail_if_no_peer_cert|depth|heartbeat)
 				[ "$val" ] || continue
 				rawVal="$val"
 				;;

--- a/3.6/debian/docker-entrypoint.sh
+++ b/3.6/debian/docker-entrypoint.sh
@@ -63,6 +63,7 @@ rabbitConfigKeys=(
 	default_pass
 	default_user
 	default_vhost
+	heartbeat
 	hipe_compile
 	vm_memory_high_watermark
 )
@@ -218,7 +219,7 @@ rabbit_env_config() {
 
 		local rawVal=
 		case "$conf" in
-			verify|fail_if_no_peer_cert|depth)
+			verify|fail_if_no_peer_cert|depth|heartbeat)
 				[ "$val" ] || continue
 				rawVal="$val"
 				;;


### PR DESCRIPTION
The `heartbeat` parameter should be configurable via an environment variable. I made it configurable with just a couple tweaks to the entrypoint.
https://www.rabbitmq.com/heartbeats.html