### PR TITLE
Swap from "gnupg2" to "gnupg"

### DIFF
--- a/3.6/debian/Dockerfile
+++ b/3.6/debian/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch-slim
 RUN set -ex; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		gnupg2 \
+		gnupg \
 		dirmngr \
 	; \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
See https://github.com/docker-library/python/issues/236 for details.