### PR TITLE
Support of queue_master_locator configuration

### DIFF
--- a/3.6/alpine/docker-entrypoint.sh
+++ b/3.6/alpine/docker-entrypoint.sh
@@ -64,6 +64,7 @@ rabbitConfigKeys=(
 	default_user
 	default_vhost
 	hipe_compile
+	queue_master_locator
 	vm_memory_high_watermark
 )
 fileConfigKeys=(

--- a/3.6/debian/docker-entrypoint.sh
+++ b/3.6/debian/docker-entrypoint.sh
@@ -64,6 +64,7 @@ rabbitConfigKeys=(
 	default_user
 	default_vhost
 	hipe_compile
+	queue_master_locator
 	vm_memory_high_watermark
 )
 fileConfigKeys=(

--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -64,6 +64,7 @@ rabbitConfigKeys=(
 	default_user
 	default_vhost
 	hipe_compile
+	queue_master_locator
 	vm_memory_high_watermark
 )
 fileConfigKeys=(

--- a/3.7-rc/alpine/docker-entrypoint.sh
+++ b/3.7-rc/alpine/docker-entrypoint.sh
@@ -64,6 +64,7 @@ rabbitConfigKeys=(
 	default_user
 	default_vhost
 	hipe_compile
+	queue_master_locator
 	vm_memory_high_watermark
 )
 fileConfigKeys=(

--- a/3.7-rc/debian/docker-entrypoint.sh
+++ b/3.7-rc/debian/docker-entrypoint.sh
@@ -64,6 +64,7 @@ rabbitConfigKeys=(
 	default_user
 	default_vhost
 	hipe_compile
+	queue_master_locator
 	vm_memory_high_watermark
 )
 fileConfigKeys=(

--- a/3.7-rc/docker-entrypoint.sh
+++ b/3.7-rc/docker-entrypoint.sh
@@ -64,6 +64,7 @@ rabbitConfigKeys=(
 	default_user
 	default_vhost
 	hipe_compile
+	queue_master_locator
 	vm_memory_high_watermark
 )
 fileConfigKeys=(

--- a/3.7/alpine/docker-entrypoint.sh
+++ b/3.7/alpine/docker-entrypoint.sh
@@ -64,6 +64,7 @@ rabbitConfigKeys=(
 	default_user
 	default_vhost
 	hipe_compile
+	queue_master_locator
 	vm_memory_high_watermark
 )
 fileConfigKeys=(

--- a/3.7/debian/docker-entrypoint.sh
+++ b/3.7/debian/docker-entrypoint.sh
@@ -64,6 +64,7 @@ rabbitConfigKeys=(
 	default_user
 	default_vhost
 	hipe_compile
+	queue_master_locator
 	vm_memory_high_watermark
 )
 fileConfigKeys=(

--- a/3.7/docker-entrypoint.sh
+++ b/3.7/docker-entrypoint.sh
@@ -64,6 +64,7 @@ rabbitConfigKeys=(
 	default_user
 	default_vhost
 	hipe_compile
+	queue_master_locator
 	vm_memory_high_watermark
 )
 fileConfigKeys=(


### PR DESCRIPTION
This PR allows to configure the [queues master location](https://www.rabbitmq.com/ha.html#queue-master-location) for RMQ clusters which can be set via RABBITMQ_QUEUE_MASTER_LOCATOR env var.