### PR TITLE
Allow users to use RABBITMQ_ERLANG_COOKIE_FILE to specify the path to an Erlang cookie file (especially for Docker secrets)

### DIFF
--- a/3.6/alpine/docker-entrypoint.sh
+++ b/3.6/alpine/docker-entrypoint.sh
@@ -45,6 +45,7 @@ fi
 fileEnvKeys=(
 	default_user
 	default_pass
+	erlang_cookie
 )
 
 # https://www.rabbitmq.com/configure.html

--- a/3.6/debian/docker-entrypoint.sh
+++ b/3.6/debian/docker-entrypoint.sh
@@ -45,6 +45,7 @@ fi
 fileEnvKeys=(
 	default_user
 	default_pass
+	erlang_cookie
 )
 
 # https://www.rabbitmq.com/configure.html

--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -45,6 +45,7 @@ fi
 fileEnvKeys=(
 	default_user
 	default_pass
+	erlang_cookie
 )
 
 # https://www.rabbitmq.com/configure.html

--- a/3.7-rc/alpine/docker-entrypoint.sh
+++ b/3.7-rc/alpine/docker-entrypoint.sh
@@ -45,6 +45,7 @@ fi
 fileEnvKeys=(
 	default_user
 	default_pass
+	erlang_cookie
 )
 
 # https://www.rabbitmq.com/configure.html

--- a/3.7-rc/debian/docker-entrypoint.sh
+++ b/3.7-rc/debian/docker-entrypoint.sh
@@ -45,6 +45,7 @@ fi
 fileEnvKeys=(
 	default_user
 	default_pass
+	erlang_cookie
 )
 
 # https://www.rabbitmq.com/configure.html

--- a/3.7-rc/docker-entrypoint.sh
+++ b/3.7-rc/docker-entrypoint.sh
@@ -45,6 +45,7 @@ fi
 fileEnvKeys=(
 	default_user
 	default_pass
+	erlang_cookie
 )
 
 # https://www.rabbitmq.com/configure.html

--- a/3.7/alpine/docker-entrypoint.sh
+++ b/3.7/alpine/docker-entrypoint.sh
@@ -45,6 +45,7 @@ fi
 fileEnvKeys=(
 	default_user
 	default_pass
+	erlang_cookie
 )
 
 # https://www.rabbitmq.com/configure.html

--- a/3.7/debian/docker-entrypoint.sh
+++ b/3.7/debian/docker-entrypoint.sh
@@ -45,6 +45,7 @@ fi
 fileEnvKeys=(
 	default_user
 	default_pass
+	erlang_cookie
 )
 
 # https://www.rabbitmq.com/configure.html

--- a/3.7/docker-entrypoint.sh
+++ b/3.7/docker-entrypoint.sh
@@ -45,6 +45,7 @@ fi
 fileEnvKeys=(
 	default_user
 	default_pass
+	erlang_cookie
 )
 
 # https://www.rabbitmq.com/configure.html


### PR DESCRIPTION
Closes #279