### PR TITLE
Only chown things in the entrypoint that are not already owned by rabbitmq

### DIFF
--- a/3.6-rc/alpine/docker-entrypoint.sh
+++ b/3.6-rc/alpine/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
 fi

--- a/3.6-rc/debian/docker-entrypoint.sh
+++ b/3.6-rc/debian/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec gosu rabbitmq "$BASH_SOURCE" "$@"
 fi

--- a/3.6-rc/docker-entrypoint.sh
+++ b/3.6-rc/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec gosu rabbitmq "$BASH_SOURCE" "$@"
 fi

--- a/3.6/alpine/docker-entrypoint.sh
+++ b/3.6/alpine/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
 fi

--- a/3.6/debian/docker-entrypoint.sh
+++ b/3.6/debian/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec gosu rabbitmq "$BASH_SOURCE" "$@"
 fi

--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec gosu rabbitmq "$BASH_SOURCE" "$@"
 fi

--- a/3.7-rc/alpine/docker-entrypoint.sh
+++ b/3.7-rc/alpine/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
 fi

--- a/3.7-rc/debian/docker-entrypoint.sh
+++ b/3.7-rc/debian/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec gosu rabbitmq "$BASH_SOURCE" "$@"
 fi

--- a/3.7-rc/docker-entrypoint.sh
+++ b/3.7-rc/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec gosu rabbitmq "$BASH_SOURCE" "$@"
 fi

--- a/3.7/alpine/docker-entrypoint.sh
+++ b/3.7/alpine/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
 fi

--- a/3.7/debian/docker-entrypoint.sh
+++ b/3.7/debian/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec gosu rabbitmq "$BASH_SOURCE" "$@"
 fi

--- a/3.7/docker-entrypoint.sh
+++ b/3.7/docker-entrypoint.sh
@@ -26,7 +26,7 @@ file_env() {
 # allow the container to be started with `--user`
 if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
 	if [ "$1" = 'rabbitmq-server' ]; then
-		chown -R rabbitmq /var/lib/rabbitmq
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
 	fi
 	exec gosu rabbitmq "$BASH_SOURCE" "$@"
 fi


### PR DESCRIPTION
Related to #279; specifically this [comment](https://github.com/docker-library/rabbitmq/issues/279#issuecomment-423987914).

Basically the same as the change in https://github.com/docker-library/postgres/pull/463 (which is included in https://github.com/docker-library/postgres/pull/496).