### PR TITLE
Copy SSL certificate files when run as root (while they're most likely to be readable by our user)

### DIFF
--- a/3.6-rc/alpine/Dockerfile
+++ b/3.6-rc/alpine/Dockerfile
@@ -78,9 +78,9 @@ RUN set -ex; \
 # set home so that any `--user` knows where to put the erlang cookie
 ENV HOME /var/lib/rabbitmq
 
-RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq \
-	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq \
-	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq
+RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl
 VOLUME /var/lib/rabbitmq
 
 # add a symlink to the .erlang.cookie in /root so we can "docker exec rabbitmqctl ..." without gosu

--- a/3.6-rc/alpine/docker-entrypoint.sh
+++ b/3.6-rc/alpine/docker-entrypoint.sh
@@ -23,14 +23,6 @@ file_env() {
 	unset "$fileVar"
 }
 
-# allow the container to be started with `--user`
-if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
-	if [ "$1" = 'rabbitmq-server' ]; then
-		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
-	fi
-	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
-fi
-
 # backwards compatibility for old environment variables
 : "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
 : "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
@@ -87,6 +79,37 @@ declare -A configDefaults=(
 	[ssl_fail_if_no_peer_cert]='true'
 	[ssl_verify]='verify_peer'
 )
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	# this needs to happen late enough that we have the SSL config
+	# https://github.com/docker-library/rabbitmq/issues/283
+	for conf in "${allConfigKeys[@]}"; do
+		var="RABBITMQ_${conf^^}"
+		val="${!var:-}"
+		[ -n "$val" ] || continue
+		case "$conf" in
+			*_ssl_*file | ssl_*file )
+				if [ -f "$val" ] && ! su-exec rabbitmq test -r "$val"; then
+					newFile="/tmp/rabbitmq-ssl/$conf.pem"
+					echo >&2
+					echo >&2 "WARNING: '$val' ($var) is not readable by rabbitmq ($(id rabbitmq)); copying to '$newFile'"
+					echo >&2
+					cat "$val" > "$newFile"
+					chown rabbitmq "$newFile"
+					chmod 0400 "$newFile"
+					eval 'export '$var'="$newFile"'
+				fi
+				;;
+		esac
+	done
+
+	if [ "$1" = 'rabbitmq-server' ]; then
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+	fi
+
+	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
+fi
 
 haveConfig=
 haveSslConfig=
@@ -156,7 +179,7 @@ for conf in "${!configDefaults[@]}"; do
 	eval "export $var=\"\$default\""
 done
 
-# If long & short hostnames are not the same, use long hostnames
+# if long and short hostnames are not the same, use long hostnames
 if [ "$(hostname)" != "$(hostname -s)" ]; then
 	: "${RABBITMQ_USE_LONGNAME:=true}"
 fi
@@ -382,7 +405,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	echo "$(rabbit_array "${fullConfig[@]}")." > /etc/rabbitmq/rabbitmq.config
 fi
 
-combinedSsl='/tmp/combined.pem'
+combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
 	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"

--- a/3.6-rc/debian/Dockerfile
+++ b/3.6-rc/debian/Dockerfile
@@ -104,9 +104,9 @@ RUN set -eux; \
 # set home so that any `--user` knows where to put the erlang cookie
 ENV HOME /var/lib/rabbitmq
 
-RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq \
-	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq \
-	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq
+RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl
 VOLUME /var/lib/rabbitmq
 
 # add a symlink to the .erlang.cookie in /root so we can "docker exec rabbitmqctl ..." without gosu

--- a/3.6/alpine/Dockerfile
+++ b/3.6/alpine/Dockerfile
@@ -78,9 +78,9 @@ RUN set -ex; \
 # set home so that any `--user` knows where to put the erlang cookie
 ENV HOME /var/lib/rabbitmq
 
-RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq \
-	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq \
-	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq
+RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl
 VOLUME /var/lib/rabbitmq
 
 # add a symlink to the .erlang.cookie in /root so we can "docker exec rabbitmqctl ..." without gosu

--- a/3.6/alpine/docker-entrypoint.sh
+++ b/3.6/alpine/docker-entrypoint.sh
@@ -23,14 +23,6 @@ file_env() {
 	unset "$fileVar"
 }
 
-# allow the container to be started with `--user`
-if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
-	if [ "$1" = 'rabbitmq-server' ]; then
-		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
-	fi
-	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
-fi
-
 # backwards compatibility for old environment variables
 : "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
 : "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
@@ -87,6 +79,37 @@ declare -A configDefaults=(
 	[ssl_fail_if_no_peer_cert]='true'
 	[ssl_verify]='verify_peer'
 )
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	# this needs to happen late enough that we have the SSL config
+	# https://github.com/docker-library/rabbitmq/issues/283
+	for conf in "${allConfigKeys[@]}"; do
+		var="RABBITMQ_${conf^^}"
+		val="${!var:-}"
+		[ -n "$val" ] || continue
+		case "$conf" in
+			*_ssl_*file | ssl_*file )
+				if [ -f "$val" ] && ! su-exec rabbitmq test -r "$val"; then
+					newFile="/tmp/rabbitmq-ssl/$conf.pem"
+					echo >&2
+					echo >&2 "WARNING: '$val' ($var) is not readable by rabbitmq ($(id rabbitmq)); copying to '$newFile'"
+					echo >&2
+					cat "$val" > "$newFile"
+					chown rabbitmq "$newFile"
+					chmod 0400 "$newFile"
+					eval 'export '$var'="$newFile"'
+				fi
+				;;
+		esac
+	done
+
+	if [ "$1" = 'rabbitmq-server' ]; then
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+	fi
+
+	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
+fi
 
 haveConfig=
 haveSslConfig=
@@ -382,7 +405,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	echo "$(rabbit_array "${fullConfig[@]}")." > /etc/rabbitmq/rabbitmq.config
 fi
 
-combinedSsl='/tmp/combined.pem'
+combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
 	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"

--- a/3.6/debian/Dockerfile
+++ b/3.6/debian/Dockerfile
@@ -104,9 +104,9 @@ RUN set -eux; \
 # set home so that any `--user` knows where to put the erlang cookie
 ENV HOME /var/lib/rabbitmq
 
-RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq \
-	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq \
-	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq
+RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl
 VOLUME /var/lib/rabbitmq
 
 # add a symlink to the .erlang.cookie in /root so we can "docker exec rabbitmqctl ..." without gosu

--- a/3.6/debian/docker-entrypoint.sh
+++ b/3.6/debian/docker-entrypoint.sh
@@ -23,14 +23,6 @@ file_env() {
 	unset "$fileVar"
 }
 
-# allow the container to be started with `--user`
-if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
-	if [ "$1" = 'rabbitmq-server' ]; then
-		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
-	fi
-	exec gosu rabbitmq "$BASH_SOURCE" "$@"
-fi
-
 # backwards compatibility for old environment variables
 : "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
 : "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
@@ -87,6 +79,37 @@ declare -A configDefaults=(
 	[ssl_fail_if_no_peer_cert]='true'
 	[ssl_verify]='verify_peer'
 )
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	# this needs to happen late enough that we have the SSL config
+	# https://github.com/docker-library/rabbitmq/issues/283
+	for conf in "${allConfigKeys[@]}"; do
+		var="RABBITMQ_${conf^^}"
+		val="${!var:-}"
+		[ -n "$val" ] || continue
+		case "$conf" in
+			*_ssl_*file | ssl_*file )
+				if [ -f "$val" ] && ! gosu rabbitmq test -r "$val"; then
+					newFile="/tmp/rabbitmq-ssl/$conf.pem"
+					echo >&2
+					echo >&2 "WARNING: '$val' ($var) is not readable by rabbitmq ($(id rabbitmq)); copying to '$newFile'"
+					echo >&2
+					cat "$val" > "$newFile"
+					chown rabbitmq "$newFile"
+					chmod 0400 "$newFile"
+					eval 'export '$var'="$newFile"'
+				fi
+				;;
+		esac
+	done
+
+	if [ "$1" = 'rabbitmq-server' ]; then
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+	fi
+
+	exec gosu rabbitmq "$BASH_SOURCE" "$@"
+fi
 
 haveConfig=
 haveSslConfig=
@@ -382,7 +405,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	echo "$(rabbit_array "${fullConfig[@]}")." > /etc/rabbitmq/rabbitmq.config
 fi
 
-combinedSsl='/tmp/combined.pem'
+combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
 	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"

--- a/3.6/docker-entrypoint.sh
+++ b/3.6/docker-entrypoint.sh
@@ -23,14 +23,6 @@ file_env() {
 	unset "$fileVar"
 }
 
-# allow the container to be started with `--user`
-if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
-	if [ "$1" = 'rabbitmq-server' ]; then
-		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
-	fi
-	exec gosu rabbitmq "$BASH_SOURCE" "$@"
-fi
-
 # backwards compatibility for old environment variables
 : "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
 : "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
@@ -87,6 +79,37 @@ declare -A configDefaults=(
 	[ssl_fail_if_no_peer_cert]='true'
 	[ssl_verify]='verify_peer'
 )
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	# this needs to happen late enough that we have the SSL config
+	# https://github.com/docker-library/rabbitmq/issues/283
+	for conf in "${allConfigKeys[@]}"; do
+		var="RABBITMQ_${conf^^}"
+		val="${!var:-}"
+		[ -n "$val" ] || continue
+		case "$conf" in
+			*_ssl_*file | ssl_*file )
+				if [ -f "$val" ] && ! gosu rabbitmq test -r "$val"; then
+					newFile="/tmp/rabbitmq-ssl/$conf.pem"
+					echo >&2
+					echo >&2 "WARNING: '$val' ($var) is not readable by rabbitmq ($(id rabbitmq)); copying to '$newFile'"
+					echo >&2
+					cat "$val" > "$newFile"
+					chown rabbitmq "$newFile"
+					chmod 0400 "$newFile"
+					eval 'export '$var'="$newFile"'
+				fi
+				;;
+		esac
+	done
+
+	if [ "$1" = 'rabbitmq-server' ]; then
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+	fi
+
+	exec gosu rabbitmq "$BASH_SOURCE" "$@"
+fi
 
 haveConfig=
 haveSslConfig=
@@ -382,7 +405,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	echo "$(rabbit_array "${fullConfig[@]}")." > /etc/rabbitmq/rabbitmq.config
 fi
 
-combinedSsl='/tmp/combined.pem'
+combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
 	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"

--- a/3.7-rc/alpine/Dockerfile
+++ b/3.7-rc/alpine/Dockerfile
@@ -78,9 +78,9 @@ RUN set -ex; \
 # set home so that any `--user` knows where to put the erlang cookie
 ENV HOME /var/lib/rabbitmq
 
-RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq \
-	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq \
-	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq
+RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl
 VOLUME /var/lib/rabbitmq
 
 # add a symlink to the .erlang.cookie in /root so we can "docker exec rabbitmqctl ..." without gosu

--- a/3.7-rc/alpine/docker-entrypoint.sh
+++ b/3.7-rc/alpine/docker-entrypoint.sh
@@ -23,14 +23,6 @@ file_env() {
 	unset "$fileVar"
 }
 
-# allow the container to be started with `--user`
-if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
-	if [ "$1" = 'rabbitmq-server' ]; then
-		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
-	fi
-	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
-fi
-
 # backwards compatibility for old environment variables
 : "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
 : "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
@@ -87,6 +79,37 @@ declare -A configDefaults=(
 	[ssl_fail_if_no_peer_cert]='true'
 	[ssl_verify]='verify_peer'
 )
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	# this needs to happen late enough that we have the SSL config
+	# https://github.com/docker-library/rabbitmq/issues/283
+	for conf in "${allConfigKeys[@]}"; do
+		var="RABBITMQ_${conf^^}"
+		val="${!var:-}"
+		[ -n "$val" ] || continue
+		case "$conf" in
+			*_ssl_*file | ssl_*file )
+				if [ -f "$val" ] && ! su-exec rabbitmq test -r "$val"; then
+					newFile="/tmp/rabbitmq-ssl/$conf.pem"
+					echo >&2
+					echo >&2 "WARNING: '$val' ($var) is not readable by rabbitmq ($(id rabbitmq)); copying to '$newFile'"
+					echo >&2
+					cat "$val" > "$newFile"
+					chown rabbitmq "$newFile"
+					chmod 0400 "$newFile"
+					eval 'export '$var'="$newFile"'
+				fi
+				;;
+		esac
+	done
+
+	if [ "$1" = 'rabbitmq-server' ]; then
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+	fi
+
+	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
+fi
 
 haveConfig=
 haveSslConfig=
@@ -362,7 +385,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	fi
 fi
 
-combinedSsl='/tmp/combined.pem'
+combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
 	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"

--- a/3.7-rc/debian/Dockerfile
+++ b/3.7-rc/debian/Dockerfile
@@ -127,9 +127,9 @@ ENV LANG C.UTF-8
 # set home so that any `--user` knows where to put the erlang cookie
 ENV HOME /var/lib/rabbitmq
 
-RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq \
-	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq \
-	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq
+RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl
 VOLUME /var/lib/rabbitmq
 
 # add a symlink to the .erlang.cookie in /root so we can "docker exec rabbitmqctl ..." without gosu

--- a/3.7-rc/debian/docker-entrypoint.sh
+++ b/3.7-rc/debian/docker-entrypoint.sh
@@ -23,14 +23,6 @@ file_env() {
 	unset "$fileVar"
 }
 
-# allow the container to be started with `--user`
-if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
-	if [ "$1" = 'rabbitmq-server' ]; then
-		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
-	fi
-	exec gosu rabbitmq "$BASH_SOURCE" "$@"
-fi
-
 # backwards compatibility for old environment variables
 : "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
 : "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
@@ -87,6 +79,37 @@ declare -A configDefaults=(
 	[ssl_fail_if_no_peer_cert]='true'
 	[ssl_verify]='verify_peer'
 )
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	# this needs to happen late enough that we have the SSL config
+	# https://github.com/docker-library/rabbitmq/issues/283
+	for conf in "${allConfigKeys[@]}"; do
+		var="RABBITMQ_${conf^^}"
+		val="${!var:-}"
+		[ -n "$val" ] || continue
+		case "$conf" in
+			*_ssl_*file | ssl_*file )
+				if [ -f "$val" ] && ! gosu rabbitmq test -r "$val"; then
+					newFile="/tmp/rabbitmq-ssl/$conf.pem"
+					echo >&2
+					echo >&2 "WARNING: '$val' ($var) is not readable by rabbitmq ($(id rabbitmq)); copying to '$newFile'"
+					echo >&2
+					cat "$val" > "$newFile"
+					chown rabbitmq "$newFile"
+					chmod 0400 "$newFile"
+					eval 'export '$var'="$newFile"'
+				fi
+				;;
+		esac
+	done
+
+	if [ "$1" = 'rabbitmq-server' ]; then
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+	fi
+
+	exec gosu rabbitmq "$BASH_SOURCE" "$@"
+fi
 
 haveConfig=
 haveSslConfig=
@@ -362,7 +385,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	fi
 fi
 
-combinedSsl='/tmp/combined.pem'
+combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
 	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"

--- a/3.7-rc/docker-entrypoint.sh
+++ b/3.7-rc/docker-entrypoint.sh
@@ -23,14 +23,6 @@ file_env() {
 	unset "$fileVar"
 }
 
-# allow the container to be started with `--user`
-if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
-	if [ "$1" = 'rabbitmq-server' ]; then
-		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
-	fi
-	exec gosu rabbitmq "$BASH_SOURCE" "$@"
-fi
-
 # backwards compatibility for old environment variables
 : "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
 : "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
@@ -87,6 +79,37 @@ declare -A configDefaults=(
 	[ssl_fail_if_no_peer_cert]='true'
 	[ssl_verify]='verify_peer'
 )
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	# this needs to happen late enough that we have the SSL config
+	# https://github.com/docker-library/rabbitmq/issues/283
+	for conf in "${allConfigKeys[@]}"; do
+		var="RABBITMQ_${conf^^}"
+		val="${!var:-}"
+		[ -n "$val" ] || continue
+		case "$conf" in
+			*_ssl_*file | ssl_*file )
+				if [ -f "$val" ] && ! gosu rabbitmq test -r "$val"; then
+					newFile="/tmp/rabbitmq-ssl/$conf.pem"
+					echo >&2
+					echo >&2 "WARNING: '$val' ($var) is not readable by rabbitmq ($(id rabbitmq)); copying to '$newFile'"
+					echo >&2
+					cat "$val" > "$newFile"
+					chown rabbitmq "$newFile"
+					chmod 0400 "$newFile"
+					eval 'export '$var'="$newFile"'
+				fi
+				;;
+		esac
+	done
+
+	if [ "$1" = 'rabbitmq-server' ]; then
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+	fi
+
+	exec gosu rabbitmq "$BASH_SOURCE" "$@"
+fi
 
 haveConfig=
 haveSslConfig=
@@ -362,7 +385,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	fi
 fi
 
-combinedSsl='/tmp/combined.pem'
+combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
 	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"

--- a/3.7/alpine/Dockerfile
+++ b/3.7/alpine/Dockerfile
@@ -78,9 +78,9 @@ RUN set -ex; \
 # set home so that any `--user` knows where to put the erlang cookie
 ENV HOME /var/lib/rabbitmq
 
-RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq \
-	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq \
-	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq
+RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl
 VOLUME /var/lib/rabbitmq
 
 # add a symlink to the .erlang.cookie in /root so we can "docker exec rabbitmqctl ..." without gosu

--- a/3.7/alpine/docker-entrypoint.sh
+++ b/3.7/alpine/docker-entrypoint.sh
@@ -23,14 +23,6 @@ file_env() {
 	unset "$fileVar"
 }
 
-# allow the container to be started with `--user`
-if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
-	if [ "$1" = 'rabbitmq-server' ]; then
-		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
-	fi
-	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
-fi
-
 # backwards compatibility for old environment variables
 : "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
 : "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
@@ -87,6 +79,37 @@ declare -A configDefaults=(
 	[ssl_fail_if_no_peer_cert]='true'
 	[ssl_verify]='verify_peer'
 )
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	# this needs to happen late enough that we have the SSL config
+	# https://github.com/docker-library/rabbitmq/issues/283
+	for conf in "${allConfigKeys[@]}"; do
+		var="RABBITMQ_${conf^^}"
+		val="${!var:-}"
+		[ -n "$val" ] || continue
+		case "$conf" in
+			*_ssl_*file | ssl_*file )
+				if [ -f "$val" ] && ! su-exec rabbitmq test -r "$val"; then
+					newFile="/tmp/rabbitmq-ssl/$conf.pem"
+					echo >&2
+					echo >&2 "WARNING: '$val' ($var) is not readable by rabbitmq ($(id rabbitmq)); copying to '$newFile'"
+					echo >&2
+					cat "$val" > "$newFile"
+					chown rabbitmq "$newFile"
+					chmod 0400 "$newFile"
+					eval 'export '$var'="$newFile"'
+				fi
+				;;
+		esac
+	done
+
+	if [ "$1" = 'rabbitmq-server' ]; then
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+	fi
+
+	exec su-exec rabbitmq "$BASH_SOURCE" "$@"
+fi
 
 haveConfig=
 haveSslConfig=
@@ -362,7 +385,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	fi
 fi
 
-combinedSsl='/tmp/combined.pem'
+combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
 	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"

--- a/3.7/debian/Dockerfile
+++ b/3.7/debian/Dockerfile
@@ -128,9 +128,9 @@ ENV LANG C.UTF-8
 # set home so that any `--user` knows where to put the erlang cookie
 ENV HOME /var/lib/rabbitmq
 
-RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq \
-	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq \
-	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq
+RUN mkdir -p /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chown -R rabbitmq:rabbitmq /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl \
+	&& chmod -R 777 /var/lib/rabbitmq /etc/rabbitmq /var/log/rabbitmq /tmp/rabbitmq-ssl
 VOLUME /var/lib/rabbitmq
 
 # add a symlink to the .erlang.cookie in /root so we can "docker exec rabbitmqctl ..." without gosu

--- a/3.7/debian/docker-entrypoint.sh
+++ b/3.7/debian/docker-entrypoint.sh
@@ -23,14 +23,6 @@ file_env() {
 	unset "$fileVar"
 }
 
-# allow the container to be started with `--user`
-if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
-	if [ "$1" = 'rabbitmq-server' ]; then
-		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
-	fi
-	exec gosu rabbitmq "$BASH_SOURCE" "$@"
-fi
-
 # backwards compatibility for old environment variables
 : "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
 : "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
@@ -87,6 +79,37 @@ declare -A configDefaults=(
 	[ssl_fail_if_no_peer_cert]='true'
 	[ssl_verify]='verify_peer'
 )
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	# this needs to happen late enough that we have the SSL config
+	# https://github.com/docker-library/rabbitmq/issues/283
+	for conf in "${allConfigKeys[@]}"; do
+		var="RABBITMQ_${conf^^}"
+		val="${!var:-}"
+		[ -n "$val" ] || continue
+		case "$conf" in
+			*_ssl_*file | ssl_*file )
+				if [ -f "$val" ] && ! gosu rabbitmq test -r "$val"; then
+					newFile="/tmp/rabbitmq-ssl/$conf.pem"
+					echo >&2
+					echo >&2 "WARNING: '$val' ($var) is not readable by rabbitmq ($(id rabbitmq)); copying to '$newFile'"
+					echo >&2
+					cat "$val" > "$newFile"
+					chown rabbitmq "$newFile"
+					chmod 0400 "$newFile"
+					eval 'export '$var'="$newFile"'
+				fi
+				;;
+		esac
+	done
+
+	if [ "$1" = 'rabbitmq-server' ]; then
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+	fi
+
+	exec gosu rabbitmq "$BASH_SOURCE" "$@"
+fi
 
 haveConfig=
 haveSslConfig=
@@ -362,7 +385,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	fi
 fi
 
-combinedSsl='/tmp/combined.pem'
+combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
 	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"

--- a/3.7/docker-entrypoint.sh
+++ b/3.7/docker-entrypoint.sh
@@ -23,14 +23,6 @@ file_env() {
 	unset "$fileVar"
 }
 
-# allow the container to be started with `--user`
-if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
-	if [ "$1" = 'rabbitmq-server' ]; then
-		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
-	fi
-	exec gosu rabbitmq "$BASH_SOURCE" "$@"
-fi
-
 # backwards compatibility for old environment variables
 : "${RABBITMQ_SSL_CERTFILE:=${RABBITMQ_SSL_CERT_FILE:-}}"
 : "${RABBITMQ_SSL_KEYFILE:=${RABBITMQ_SSL_KEY_FILE:-}}"
@@ -87,6 +79,37 @@ declare -A configDefaults=(
 	[ssl_fail_if_no_peer_cert]='true'
 	[ssl_verify]='verify_peer'
 )
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	# this needs to happen late enough that we have the SSL config
+	# https://github.com/docker-library/rabbitmq/issues/283
+	for conf in "${allConfigKeys[@]}"; do
+		var="RABBITMQ_${conf^^}"
+		val="${!var:-}"
+		[ -n "$val" ] || continue
+		case "$conf" in
+			*_ssl_*file | ssl_*file )
+				if [ -f "$val" ] && ! gosu rabbitmq test -r "$val"; then
+					newFile="/tmp/rabbitmq-ssl/$conf.pem"
+					echo >&2
+					echo >&2 "WARNING: '$val' ($var) is not readable by rabbitmq ($(id rabbitmq)); copying to '$newFile'"
+					echo >&2
+					cat "$val" > "$newFile"
+					chown rabbitmq "$newFile"
+					chmod 0400 "$newFile"
+					eval 'export '$var'="$newFile"'
+				fi
+				;;
+		esac
+	done
+
+	if [ "$1" = 'rabbitmq-server' ]; then
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+	fi
+
+	exec gosu rabbitmq "$BASH_SOURCE" "$@"
+fi
 
 haveConfig=
 haveSslConfig=
@@ -362,7 +385,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	fi
 fi
 
-combinedSsl='/tmp/combined.pem'
+combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
 	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"


### PR DESCRIPTION
Closes #283

This adjusts our step-down-from-`root` code to also copy any relevant SSL certificate files and `chown`/`chmod` them appropriately so that our new user can read them (since the ones provided by the container user likely are difficult to provide with appropriate permissions for the `rabbitmq` user).