### PR TITLE
Fix shared library loading preference on non-x86 architectures (especially those like aarch64 which sort lexicographically ahead of "libc.conf")

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,17 @@ services: docker
 
 env:
   - VERSION=3.8-rc VARIANT=ubuntu
+  - VERSION=3.8-rc VARIANT=ubuntu ARCH=i386
   - VERSION=3.8-rc VARIANT=alpine
+  - VERSION=3.8-rc VARIANT=alpine ARCH=i386
   - VERSION=3.7-rc VARIANT=ubuntu
+  - VERSION=3.7-rc VARIANT=ubuntu ARCH=i386
   - VERSION=3.7-rc VARIANT=alpine
+  - VERSION=3.7-rc VARIANT=alpine ARCH=i386
   - VERSION=3.7 VARIANT=ubuntu
+  - VERSION=3.7 VARIANT=ubuntu ARCH=i386
   - VERSION=3.7 VARIANT=alpine
+  - VERSION=3.7 VARIANT=alpine ARCH=i386
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images
@@ -17,6 +23,16 @@ before_script:
   - wget -qO- 'https://github.com/tianon/pgp-happy-eyeballs/raw/master/hack-my-builds.sh' | bash
   - cd "$VERSION/$VARIANT"
   - image="$(awk 'toupper($1) == "FROM" { print $2; exit }' management/Dockerfile)"
+  - |
+    (
+      set -Eeuo pipefail
+      set -x
+      if [ -n "${ARCH:-}" ]; then
+        from="$(awk '$1 == toupper("FROM") { print $2 }' Dockerfile)"
+        docker pull "$ARCH/$from"
+        docker tag "$ARCH/$from" "$from"
+      fi
+    )
 
 script:
   - |

--- a/3.7-rc/alpine/Dockerfile
+++ b/3.7-rc/alpine/Dockerfile
@@ -67,6 +67,11 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# OpenSSL's "config" script uses a lot of "uname"-based target detection...
+	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
+	RELEASE="4.x.y-z" \
+	SYSTEM='Linux' \
+	BUILD='???' \
 	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \

--- a/3.7-rc/ubuntu/Dockerfile
+++ b/3.7-rc/ubuntu/Dockerfile
@@ -80,6 +80,9 @@ RUN set -eux; \
 	make install_sw install_ssldirs; \
 	cd ..; \
 	rm -rf "$OPENSSL_PATH"*; \
+# this is included in "/etc/ld.so.conf.d/libc.conf", but on arm64, it gets overshadowed by "/etc/ld.so.conf.d/aarch64-linux-gnu.conf" (vs "/etc/ld.so.conf.d/x86_64-linux-gnu.conf") so the precedence isn't correct -- we install our own file to overcome that and ensure any .so files in /usr/local/lib (especially OpenSSL's libssl.so) are preferred appropriately regardless of the target architecture
+# see https://bugs.debian.org/685706
+	echo '/usr/local/lib' > /etc/ld.so.conf.d/000-openssl-libc.conf; \
 	ldconfig; \
 # use Debian's CA certificates
 	rmdir "$OPENSSL_CONFIG_DIR/certs" "$OPENSSL_CONFIG_DIR/private"; \

--- a/3.7-rc/ubuntu/Dockerfile
+++ b/3.7-rc/ubuntu/Dockerfile
@@ -74,6 +74,11 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# OpenSSL's "config" script uses a lot of "uname"-based target detection...
+	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
+	RELEASE="4.x.y-z" \
+	SYSTEM='Linux' \
+	BUILD='???' \
 	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \

--- a/3.7/alpine/Dockerfile
+++ b/3.7/alpine/Dockerfile
@@ -67,6 +67,11 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# OpenSSL's "config" script uses a lot of "uname"-based target detection...
+	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
+	RELEASE="4.x.y-z" \
+	SYSTEM='Linux' \
+	BUILD='???' \
 	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \

--- a/3.7/ubuntu/Dockerfile
+++ b/3.7/ubuntu/Dockerfile
@@ -80,6 +80,9 @@ RUN set -eux; \
 	make install_sw install_ssldirs; \
 	cd ..; \
 	rm -rf "$OPENSSL_PATH"*; \
+# this is included in "/etc/ld.so.conf.d/libc.conf", but on arm64, it gets overshadowed by "/etc/ld.so.conf.d/aarch64-linux-gnu.conf" (vs "/etc/ld.so.conf.d/x86_64-linux-gnu.conf") so the precedence isn't correct -- we install our own file to overcome that and ensure any .so files in /usr/local/lib (especially OpenSSL's libssl.so) are preferred appropriately regardless of the target architecture
+# see https://bugs.debian.org/685706
+	echo '/usr/local/lib' > /etc/ld.so.conf.d/000-openssl-libc.conf; \
 	ldconfig; \
 # use Debian's CA certificates
 	rmdir "$OPENSSL_CONFIG_DIR/certs" "$OPENSSL_CONFIG_DIR/private"; \

--- a/3.7/ubuntu/Dockerfile
+++ b/3.7/ubuntu/Dockerfile
@@ -74,6 +74,11 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# OpenSSL's "config" script uses a lot of "uname"-based target detection...
+	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
+	RELEASE="4.x.y-z" \
+	SYSTEM='Linux' \
+	BUILD='???' \
 	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \

--- a/3.8-rc/alpine/Dockerfile
+++ b/3.8-rc/alpine/Dockerfile
@@ -67,6 +67,11 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# OpenSSL's "config" script uses a lot of "uname"-based target detection...
+	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
+	RELEASE="4.x.y-z" \
+	SYSTEM='Linux' \
+	BUILD='???' \
 	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \

--- a/3.8-rc/ubuntu/Dockerfile
+++ b/3.8-rc/ubuntu/Dockerfile
@@ -80,6 +80,9 @@ RUN set -eux; \
 	make install_sw install_ssldirs; \
 	cd ..; \
 	rm -rf "$OPENSSL_PATH"*; \
+# this is included in "/etc/ld.so.conf.d/libc.conf", but on arm64, it gets overshadowed by "/etc/ld.so.conf.d/aarch64-linux-gnu.conf" (vs "/etc/ld.so.conf.d/x86_64-linux-gnu.conf") so the precedence isn't correct -- we install our own file to overcome that and ensure any .so files in /usr/local/lib (especially OpenSSL's libssl.so) are preferred appropriately regardless of the target architecture
+# see https://bugs.debian.org/685706
+	echo '/usr/local/lib' > /etc/ld.so.conf.d/000-openssl-libc.conf; \
 	ldconfig; \
 # use Debian's CA certificates
 	rmdir "$OPENSSL_CONFIG_DIR/certs" "$OPENSSL_CONFIG_DIR/private"; \

--- a/3.8-rc/ubuntu/Dockerfile
+++ b/3.8-rc/ubuntu/Dockerfile
@@ -74,6 +74,11 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# OpenSSL's "config" script uses a lot of "uname"-based target detection...
+	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
+	RELEASE="4.x.y-z" \
+	SYSTEM='Linux' \
+	BUILD='???' \
 	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -67,6 +67,11 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# OpenSSL's "config" script uses a lot of "uname"-based target detection...
+	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
+	RELEASE="4.x.y-z" \
+	SYSTEM='Linux' \
+	BUILD='???' \
 	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -80,6 +80,9 @@ RUN set -eux; \
 	make install_sw install_ssldirs; \
 	cd ..; \
 	rm -rf "$OPENSSL_PATH"*; \
+# this is included in "/etc/ld.so.conf.d/libc.conf", but on arm64, it gets overshadowed by "/etc/ld.so.conf.d/aarch64-linux-gnu.conf" (vs "/etc/ld.so.conf.d/x86_64-linux-gnu.conf") so the precedence isn't correct -- we install our own file to overcome that and ensure any .so files in /usr/local/lib (especially OpenSSL's libssl.so) are preferred appropriately regardless of the target architecture
+# see https://bugs.debian.org/685706
+	echo '/usr/local/lib' > /etc/ld.so.conf.d/000-openssl-libc.conf; \
 	ldconfig; \
 # use Debian's CA certificates
 	rmdir "$OPENSSL_CONFIG_DIR/certs" "$OPENSSL_CONFIG_DIR/private"; \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -74,6 +74,11 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# OpenSSL's "config" script uses a lot of "uname"-based target detection...
+	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
+	RELEASE="4.x.y-z" \
+	SYSTEM='Linux' \
+	BUILD='???' \
 	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \

--- a/update.sh
+++ b/update.sh
@@ -116,6 +116,7 @@ for version in "${versions[@]}"; do
 			Dockerfile-management.template \
 			> "$version/$variant/management/Dockerfile"
 
+		travisEnv='\n  - VERSION='"$version"' VARIANT='"$variant ARCH=i386$travisEnv"
 		travisEnv='\n  - VERSION='"$version"' VARIANT='"$variant$travisEnv"
 	done
 done


### PR DESCRIPTION
See https://bugs.debian.org/685706 for the upstream bug report.

See https://doi-janky.infosiftr.net/job/multiarch/job/arm64v8/job/rabbitmq/116/console for an example failing build.