### PR TITLE
Adjust Erlang HiPE compilation to be conditional based on architecture

### DIFF
--- a/3.7-rc/alpine/Dockerfile
+++ b/3.7-rc/alpine/Dockerfile
@@ -106,14 +106,20 @@ RUN set -eux; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
+	case "$dpkgArch" in \
+# https://salsa.debian.org/erlang-team/packages/erlang/blob/9e3466473f1c75f6f6866c9957f6c4f535c12c70/debian/control#L40 (HiPE supports a limited set of architectures)
+		amd64 | i386 | ppc64el) hipe='--enable-hipe' ;; \
+		*) hipe='--disable-hipe' ;; \
+	esac; \
 	./configure \
 		--host="$hostArch" \
 		--build="$buildArch" \
+		$hipe \
 		--disable-dynamic-ssl-lib \
 		--disable-sctp \
 		--disable-silent-rules \
 		--enable-clock-gettime \
-		--enable-hipe \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
 		--enable-shared-zlib \

--- a/3.7-rc/ubuntu/Dockerfile
+++ b/3.7-rc/ubuntu/Dockerfile
@@ -111,14 +111,20 @@ RUN set -eux; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
+	case "$dpkgArch" in \
+# https://salsa.debian.org/erlang-team/packages/erlang/blob/9e3466473f1c75f6f6866c9957f6c4f535c12c70/debian/control#L40 (HiPE supports a limited set of architectures)
+		amd64 | i386 | ppc64el) hipe='--enable-hipe' ;; \
+		*) hipe='--disable-hipe' ;; \
+	esac; \
 	./configure \
 		--host="$hostArch" \
 		--build="$buildArch" \
+		$hipe \
 		--disable-dynamic-ssl-lib \
 		--disable-sctp \
 		--disable-silent-rules \
 		--enable-clock-gettime \
-		--enable-hipe \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
 		--enable-shared-zlib \

--- a/3.7/alpine/Dockerfile
+++ b/3.7/alpine/Dockerfile
@@ -106,14 +106,20 @@ RUN set -eux; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
+	case "$dpkgArch" in \
+# https://salsa.debian.org/erlang-team/packages/erlang/blob/9e3466473f1c75f6f6866c9957f6c4f535c12c70/debian/control#L40 (HiPE supports a limited set of architectures)
+		amd64 | i386 | ppc64el) hipe='--enable-hipe' ;; \
+		*) hipe='--disable-hipe' ;; \
+	esac; \
 	./configure \
 		--host="$hostArch" \
 		--build="$buildArch" \
+		$hipe \
 		--disable-dynamic-ssl-lib \
 		--disable-sctp \
 		--disable-silent-rules \
 		--enable-clock-gettime \
-		--enable-hipe \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
 		--enable-shared-zlib \

--- a/3.7/ubuntu/Dockerfile
+++ b/3.7/ubuntu/Dockerfile
@@ -111,14 +111,20 @@ RUN set -eux; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
+	case "$dpkgArch" in \
+# https://salsa.debian.org/erlang-team/packages/erlang/blob/9e3466473f1c75f6f6866c9957f6c4f535c12c70/debian/control#L40 (HiPE supports a limited set of architectures)
+		amd64 | i386 | ppc64el) hipe='--enable-hipe' ;; \
+		*) hipe='--disable-hipe' ;; \
+	esac; \
 	./configure \
 		--host="$hostArch" \
 		--build="$buildArch" \
+		$hipe \
 		--disable-dynamic-ssl-lib \
 		--disable-sctp \
 		--disable-silent-rules \
 		--enable-clock-gettime \
-		--enable-hipe \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
 		--enable-shared-zlib \

--- a/3.8-rc/alpine/Dockerfile
+++ b/3.8-rc/alpine/Dockerfile
@@ -106,14 +106,20 @@ RUN set -eux; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
+	case "$dpkgArch" in \
+# https://salsa.debian.org/erlang-team/packages/erlang/blob/9e3466473f1c75f6f6866c9957f6c4f535c12c70/debian/control#L40 (HiPE supports a limited set of architectures)
+		amd64 | i386 | ppc64el) hipe='--enable-hipe' ;; \
+		*) hipe='--disable-hipe' ;; \
+	esac; \
 	./configure \
 		--host="$hostArch" \
 		--build="$buildArch" \
+		$hipe \
 		--disable-dynamic-ssl-lib \
 		--disable-sctp \
 		--disable-silent-rules \
 		--enable-clock-gettime \
-		--enable-hipe \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
 		--enable-shared-zlib \

--- a/3.8-rc/ubuntu/Dockerfile
+++ b/3.8-rc/ubuntu/Dockerfile
@@ -111,14 +111,20 @@ RUN set -eux; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
+	case "$dpkgArch" in \
+# https://salsa.debian.org/erlang-team/packages/erlang/blob/9e3466473f1c75f6f6866c9957f6c4f535c12c70/debian/control#L40 (HiPE supports a limited set of architectures)
+		amd64 | i386 | ppc64el) hipe='--enable-hipe' ;; \
+		*) hipe='--disable-hipe' ;; \
+	esac; \
 	./configure \
 		--host="$hostArch" \
 		--build="$buildArch" \
+		$hipe \
 		--disable-dynamic-ssl-lib \
 		--disable-sctp \
 		--disable-silent-rules \
 		--enable-clock-gettime \
-		--enable-hipe \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
 		--enable-shared-zlib \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -106,14 +106,20 @@ RUN set -eux; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
+	case "$dpkgArch" in \
+# https://salsa.debian.org/erlang-team/packages/erlang/blob/9e3466473f1c75f6f6866c9957f6c4f535c12c70/debian/control#L40 (HiPE supports a limited set of architectures)
+		amd64 | i386 | ppc64el) hipe='--enable-hipe' ;; \
+		*) hipe='--disable-hipe' ;; \
+	esac; \
 	./configure \
 		--host="$hostArch" \
 		--build="$buildArch" \
+		$hipe \
 		--disable-dynamic-ssl-lib \
 		--disable-sctp \
 		--disable-silent-rules \
 		--enable-clock-gettime \
-		--enable-hipe \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
 		--enable-shared-zlib \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -111,14 +111,20 @@ RUN set -eux; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
+	case "$dpkgArch" in \
+# https://salsa.debian.org/erlang-team/packages/erlang/blob/9e3466473f1c75f6f6866c9957f6c4f535c12c70/debian/control#L40 (HiPE supports a limited set of architectures)
+		amd64 | i386 | ppc64el) hipe='--enable-hipe' ;; \
+		*) hipe='--disable-hipe' ;; \
+	esac; \
 	./configure \
 		--host="$hostArch" \
 		--build="$buildArch" \
+		$hipe \
 		--disable-dynamic-ssl-lib \
 		--disable-sctp \
 		--disable-silent-rules \
 		--enable-clock-gettime \
-		--enable-hipe \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
 		--enable-shared-zlib \


### PR DESCRIPTION
HiPE is only supported on a limited set of architectures, so our `./configure` flags should reflect that (this causing us build failures on several architectures: https://doi-janky.infosiftr.net/job/multiarch/view/images/view/rabbitmq/).

I've successfully tested this change on `arm32v7`, `amd64`, `ppc64le`, and `s390x`.

Fixes #327

(My `arm32v7` test is technically still building, but it's past the point it failed previously.)