### PR TITLE
Add "--libdir" to openssl compilation to fix arm32v7

### DIFF
--- a/3.7-rc/ubuntu/Dockerfile
+++ b/3.7-rc/ubuntu/Dockerfile
@@ -72,12 +72,14 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# without specifying "--libdir", Erlang will fail during "crypto:supports()" looking for a "pthread_atfork" function that doesn't exist (but only on arm32v7/armhf??)
+	debMultiarch="$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 # OpenSSL's "config" script uses a lot of "uname"-based target detection...
 	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
+	./config --openssldir="$OPENSSL_CONFIG_DIR" --libdir="lib/$debMultiarch"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \

--- a/3.7/ubuntu/Dockerfile
+++ b/3.7/ubuntu/Dockerfile
@@ -72,12 +72,14 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# without specifying "--libdir", Erlang will fail during "crypto:supports()" looking for a "pthread_atfork" function that doesn't exist (but only on arm32v7/armhf??)
+	debMultiarch="$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 # OpenSSL's "config" script uses a lot of "uname"-based target detection...
 	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
+	./config --openssldir="$OPENSSL_CONFIG_DIR" --libdir="lib/$debMultiarch"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \

--- a/3.8-rc/ubuntu/Dockerfile
+++ b/3.8-rc/ubuntu/Dockerfile
@@ -72,12 +72,14 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# without specifying "--libdir", Erlang will fail during "crypto:supports()" looking for a "pthread_atfork" function that doesn't exist (but only on arm32v7/armhf??)
+	debMultiarch="$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 # OpenSSL's "config" script uses a lot of "uname"-based target detection...
 	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
+	./config --openssldir="$OPENSSL_CONFIG_DIR" --libdir="lib/$debMultiarch"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -72,12 +72,14 @@ RUN set -eux; \
 	\
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
+# without specifying "--libdir", Erlang will fail during "crypto:supports()" looking for a "pthread_atfork" function that doesn't exist (but only on arm32v7/armhf??)
+	debMultiarch="$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 # OpenSSL's "config" script uses a lot of "uname"-based target detection...
 	MACHINE="$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
+	./config --openssldir="$OPENSSL_CONFIG_DIR" --libdir="lib/$debMultiarch"; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \


### PR DESCRIPTION
See https://salsa.debian.org/debian/openssl/blob/30ca49131a4b06ea10acc48c8404bb4869b04ff7/debian/rules#L32 for where this comes from -- essentially without this, Erlang doesn't pick up `libpthread.so` properly as a dependency of `crypto.so` (which causes `crypto:supports()` to fail to load).