### PR TITLE
Add a line of whitespace between certs in "combined.pem"

### DIFF
--- a/3.7-rc/alpine/docker-entrypoint.sh
+++ b/3.7-rc/alpine/docker-entrypoint.sh
@@ -387,7 +387,11 @@ fi
 combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
-	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"
+	{
+		cat "$RABBITMQ_SSL_CERTFILE"
+		echo # https://github.com/docker-library/rabbitmq/issues/357#issuecomment-517755647
+		cat "$RABBITMQ_SSL_KEYFILE"
+	} > "$combinedSsl"
 	chmod 0400 "$combinedSsl"
 fi
 if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then

--- a/3.7-rc/ubuntu/docker-entrypoint.sh
+++ b/3.7-rc/ubuntu/docker-entrypoint.sh
@@ -387,7 +387,11 @@ fi
 combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
-	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"
+	{
+		cat "$RABBITMQ_SSL_CERTFILE"
+		echo # https://github.com/docker-library/rabbitmq/issues/357#issuecomment-517755647
+		cat "$RABBITMQ_SSL_KEYFILE"
+	} > "$combinedSsl"
 	chmod 0400 "$combinedSsl"
 fi
 if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then

--- a/3.7/alpine/docker-entrypoint.sh
+++ b/3.7/alpine/docker-entrypoint.sh
@@ -387,7 +387,11 @@ fi
 combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
-	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"
+	{
+		cat "$RABBITMQ_SSL_CERTFILE"
+		echo # https://github.com/docker-library/rabbitmq/issues/357#issuecomment-517755647
+		cat "$RABBITMQ_SSL_KEYFILE"
+	} > "$combinedSsl"
 	chmod 0400 "$combinedSsl"
 fi
 if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then

--- a/3.7/ubuntu/docker-entrypoint.sh
+++ b/3.7/ubuntu/docker-entrypoint.sh
@@ -387,7 +387,11 @@ fi
 combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
-	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"
+	{
+		cat "$RABBITMQ_SSL_CERTFILE"
+		echo # https://github.com/docker-library/rabbitmq/issues/357#issuecomment-517755647
+		cat "$RABBITMQ_SSL_KEYFILE"
+	} > "$combinedSsl"
 	chmod 0400 "$combinedSsl"
 fi
 if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then

--- a/3.8-rc/alpine/docker-entrypoint.sh
+++ b/3.8-rc/alpine/docker-entrypoint.sh
@@ -387,7 +387,11 @@ fi
 combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
-	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"
+	{
+		cat "$RABBITMQ_SSL_CERTFILE"
+		echo # https://github.com/docker-library/rabbitmq/issues/357#issuecomment-517755647
+		cat "$RABBITMQ_SSL_KEYFILE"
+	} > "$combinedSsl"
 	chmod 0400 "$combinedSsl"
 fi
 if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then

--- a/3.8-rc/ubuntu/docker-entrypoint.sh
+++ b/3.8-rc/ubuntu/docker-entrypoint.sh
@@ -387,7 +387,11 @@ fi
 combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
-	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"
+	{
+		cat "$RABBITMQ_SSL_CERTFILE"
+		echo # https://github.com/docker-library/rabbitmq/issues/357#issuecomment-517755647
+		cat "$RABBITMQ_SSL_KEYFILE"
+	} > "$combinedSsl"
 	chmod 0400 "$combinedSsl"
 fi
 if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -387,7 +387,11 @@ fi
 combinedSsl='/tmp/rabbitmq-ssl/combined.pem'
 if [ "$haveSslConfig" ] && [[ "$1" == rabbitmq* ]] && [ ! -f "$combinedSsl" ]; then
 	# Create combined cert
-	cat "$RABBITMQ_SSL_CERTFILE" "$RABBITMQ_SSL_KEYFILE" > "$combinedSsl"
+	{
+		cat "$RABBITMQ_SSL_CERTFILE"
+		echo # https://github.com/docker-library/rabbitmq/issues/357#issuecomment-517755647
+		cat "$RABBITMQ_SSL_KEYFILE"
+	} > "$combinedSsl"
 	chmod 0400 "$combinedSsl"
 fi
 if [ "$haveSslConfig" ] && [ -f "$combinedSsl" ]; then


### PR DESCRIPTION
This is important if `$RABBITMQ_SSL_CERTFILE` does not end with a newline.

Closes #357