### PR TITLE
Ditch both LD_LIBRARY_PATH and /etc/ld.so.conf in favor of rpath

### DIFF
--- a/3.7-rc/alpine/Dockerfile
+++ b/3.7-rc/alpine/Dockerfile
@@ -15,9 +15,6 @@ ARG PGP_KEYSERVER=ha.pool.sks-keyservers.net
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:3.7 --build-arg PGP_KEYSERVER=pgpkeys.eu 3.7/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-# avoid conflicts between our OpenSSL's "libssl.so" and Alpine's by making sure /usr/local/lib is searched first
-ENV LD_LIBRARY_PATH /usr/local/lib
-
 # Using the latest OpenSSL LTS release, with support until September 2023 - https://www.openssl.org/source/
 ENV OPENSSL_VERSION 1.1.1c
 ENV OPENSSL_SOURCE_SHA256="f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90"
@@ -78,7 +75,11 @@ RUN set -eux; \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
+	./config \
+		--openssldir="$OPENSSL_CONFIG_DIR" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath=/usr/local/lib \
+	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \
@@ -106,6 +107,8 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	./otp_build autoconf; \
 	export CFLAGS='-g -O2'; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \

--- a/3.7-rc/ubuntu/Dockerfile
+++ b/3.7-rc/ubuntu/Dockerfile
@@ -79,15 +79,17 @@ RUN set -eux; \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR" --libdir="lib/$debMultiarch"; \
+	./config \
+		--openssldir="$OPENSSL_CONFIG_DIR" \
+		--libdir="lib/$debMultiarch" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath=/usr/local/lib \
+	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \
 	cd ..; \
 	rm -rf "$OPENSSL_PATH"*; \
-# this is included in "/etc/ld.so.conf.d/libc.conf", but on arm64, it gets overshadowed by "/etc/ld.so.conf.d/aarch64-linux-gnu.conf" (vs "/etc/ld.so.conf.d/x86_64-linux-gnu.conf") so the precedence isn't correct -- we install our own file to overcome that and ensure any .so files in /usr/local/lib (especially OpenSSL's libssl.so) are preferred appropriately regardless of the target architecture
-# see https://bugs.debian.org/685706
-	echo '/usr/local/lib' > /etc/ld.so.conf.d/000-openssl-libc.conf; \
 	ldconfig; \
 # use Debian's CA certificates
 	rmdir "$OPENSSL_CONFIG_DIR/certs" "$OPENSSL_CONFIG_DIR/private"; \
@@ -111,6 +113,8 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	./otp_build autoconf; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \

--- a/3.7/alpine/Dockerfile
+++ b/3.7/alpine/Dockerfile
@@ -15,9 +15,6 @@ ARG PGP_KEYSERVER=ha.pool.sks-keyservers.net
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:3.7 --build-arg PGP_KEYSERVER=pgpkeys.eu 3.7/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-# avoid conflicts between our OpenSSL's "libssl.so" and Alpine's by making sure /usr/local/lib is searched first
-ENV LD_LIBRARY_PATH /usr/local/lib
-
 # Using the latest OpenSSL LTS release, with support until September 2023 - https://www.openssl.org/source/
 ENV OPENSSL_VERSION 1.1.1c
 ENV OPENSSL_SOURCE_SHA256="f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90"
@@ -78,7 +75,11 @@ RUN set -eux; \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
+	./config \
+		--openssldir="$OPENSSL_CONFIG_DIR" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath=/usr/local/lib \
+	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \
@@ -106,6 +107,8 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	./otp_build autoconf; \
 	export CFLAGS='-g -O2'; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \

--- a/3.7/ubuntu/Dockerfile
+++ b/3.7/ubuntu/Dockerfile
@@ -79,15 +79,17 @@ RUN set -eux; \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR" --libdir="lib/$debMultiarch"; \
+	./config \
+		--openssldir="$OPENSSL_CONFIG_DIR" \
+		--libdir="lib/$debMultiarch" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath=/usr/local/lib \
+	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \
 	cd ..; \
 	rm -rf "$OPENSSL_PATH"*; \
-# this is included in "/etc/ld.so.conf.d/libc.conf", but on arm64, it gets overshadowed by "/etc/ld.so.conf.d/aarch64-linux-gnu.conf" (vs "/etc/ld.so.conf.d/x86_64-linux-gnu.conf") so the precedence isn't correct -- we install our own file to overcome that and ensure any .so files in /usr/local/lib (especially OpenSSL's libssl.so) are preferred appropriately regardless of the target architecture
-# see https://bugs.debian.org/685706
-	echo '/usr/local/lib' > /etc/ld.so.conf.d/000-openssl-libc.conf; \
 	ldconfig; \
 # use Debian's CA certificates
 	rmdir "$OPENSSL_CONFIG_DIR/certs" "$OPENSSL_CONFIG_DIR/private"; \
@@ -111,6 +113,8 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	./otp_build autoconf; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \

--- a/3.8-rc/alpine/Dockerfile
+++ b/3.8-rc/alpine/Dockerfile
@@ -15,9 +15,6 @@ ARG PGP_KEYSERVER=ha.pool.sks-keyservers.net
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:3.7 --build-arg PGP_KEYSERVER=pgpkeys.eu 3.7/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-# avoid conflicts between our OpenSSL's "libssl.so" and Alpine's by making sure /usr/local/lib is searched first
-ENV LD_LIBRARY_PATH /usr/local/lib
-
 # Using the latest OpenSSL LTS release, with support until September 2023 - https://www.openssl.org/source/
 ENV OPENSSL_VERSION 1.1.1c
 ENV OPENSSL_SOURCE_SHA256="f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90"
@@ -78,7 +75,11 @@ RUN set -eux; \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
+	./config \
+		--openssldir="$OPENSSL_CONFIG_DIR" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath=/usr/local/lib \
+	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \
@@ -106,6 +107,8 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	./otp_build autoconf; \
 	export CFLAGS='-g -O2'; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \

--- a/3.8-rc/ubuntu/Dockerfile
+++ b/3.8-rc/ubuntu/Dockerfile
@@ -79,15 +79,17 @@ RUN set -eux; \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR" --libdir="lib/$debMultiarch"; \
+	./config \
+		--openssldir="$OPENSSL_CONFIG_DIR" \
+		--libdir="lib/$debMultiarch" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath=/usr/local/lib \
+	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \
 	cd ..; \
 	rm -rf "$OPENSSL_PATH"*; \
-# this is included in "/etc/ld.so.conf.d/libc.conf", but on arm64, it gets overshadowed by "/etc/ld.so.conf.d/aarch64-linux-gnu.conf" (vs "/etc/ld.so.conf.d/x86_64-linux-gnu.conf") so the precedence isn't correct -- we install our own file to overcome that and ensure any .so files in /usr/local/lib (especially OpenSSL's libssl.so) are preferred appropriately regardless of the target architecture
-# see https://bugs.debian.org/685706
-	echo '/usr/local/lib' > /etc/ld.so.conf.d/000-openssl-libc.conf; \
 	ldconfig; \
 # use Debian's CA certificates
 	rmdir "$OPENSSL_CONFIG_DIR/certs" "$OPENSSL_CONFIG_DIR/private"; \
@@ -111,6 +113,8 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	./otp_build autoconf; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -15,9 +15,6 @@ ARG PGP_KEYSERVER=ha.pool.sks-keyservers.net
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:3.7 --build-arg PGP_KEYSERVER=pgpkeys.eu 3.7/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-# avoid conflicts between our OpenSSL's "libssl.so" and Alpine's by making sure /usr/local/lib is searched first
-ENV LD_LIBRARY_PATH /usr/local/lib
-
 # Using the latest OpenSSL LTS release, with support until September 2023 - https://www.openssl.org/source/
 ENV OPENSSL_VERSION %%OPENSSL_VERSION%%
 ENV OPENSSL_SOURCE_SHA256="%%OPENSSL_SOURCE_SHA256%%"
@@ -78,7 +75,11 @@ RUN set -eux; \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR"; \
+	./config \
+		--openssldir="$OPENSSL_CONFIG_DIR" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath=/usr/local/lib \
+	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \
@@ -106,6 +107,8 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	./otp_build autoconf; \
 	export CFLAGS='-g -O2'; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -79,15 +79,17 @@ RUN set -eux; \
 	RELEASE="4.x.y-z" \
 	SYSTEM='Linux' \
 	BUILD='???' \
-	./config --openssldir="$OPENSSL_CONFIG_DIR" --libdir="lib/$debMultiarch"; \
+	./config \
+		--openssldir="$OPENSSL_CONFIG_DIR" \
+		--libdir="lib/$debMultiarch" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath=/usr/local/lib \
+	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
 	make -j "$(getconf _NPROCESSORS_ONLN)"; \
 	make install_sw install_ssldirs; \
 	cd ..; \
 	rm -rf "$OPENSSL_PATH"*; \
-# this is included in "/etc/ld.so.conf.d/libc.conf", but on arm64, it gets overshadowed by "/etc/ld.so.conf.d/aarch64-linux-gnu.conf" (vs "/etc/ld.so.conf.d/x86_64-linux-gnu.conf") so the precedence isn't correct -- we install our own file to overcome that and ensure any .so files in /usr/local/lib (especially OpenSSL's libssl.so) are preferred appropriately regardless of the target architecture
-# see https://bugs.debian.org/685706
-	echo '/usr/local/lib' > /etc/ld.so.conf.d/000-openssl-libc.conf; \
 	ldconfig; \
 # use Debian's CA certificates
 	rmdir "$OPENSSL_CONFIG_DIR/certs" "$OPENSSL_CONFIG_DIR/private"; \
@@ -111,6 +113,8 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	./otp_build autoconf; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \


### PR DESCRIPTION
This compiles `erl` and `openssl` such that they pick up the right `libssl.so` automatically without any system tweaking (see https://en.wikipedia.org/wiki/Rpath for more information about `rpath` sections in executables).

Closes #364
Replaces/improves #310 (tested on arm64 to be sure :metal:)