### PR TITLE
Add support for read-only config file mounts

### DIFF
--- a/3.7-rc/alpine/docker-entrypoint.sh
+++ b/3.7-rc/alpine/docker-entrypoint.sh
@@ -202,7 +202,7 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
 	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
 	tmp="/tmp/rabbitmq.conf"
 	cat "$newConfigFile" > "${tmp}"

--- a/3.7-rc/alpine/docker-entrypoint.sh
+++ b/3.7-rc/alpine/docker-entrypoint.sh
@@ -202,6 +202,13 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
+	tmp="/tmp/rabbitmq.conf"
+	cat "$newConfigFile" > "${tmp}"
+	newConfigFile="${tmp}"
+	export RABBITMQ_CONFIG_FILE="${tmp}"
+fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{
 		echo "error: Docker configuration environment variables specified, but old-style (Erlang syntax) configuration file '$oldConfigFile' exists"

--- a/3.7-rc/alpine/docker-entrypoint.sh
+++ b/3.7-rc/alpine/docker-entrypoint.sh
@@ -202,12 +202,15 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
-	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
-	tmp="/tmp/rabbitmq.conf"
-	cat "$newConfigFile" > "${tmp}"
-	newConfigFile="${tmp}"
-	export RABBITMQ_CONFIG_FILE="${tmp}"
+if [ -n "$shouldWriteConfig" ] && ! touch "$newConfigFile"; then
+	# config file exists but it isn't writeable (likely read-only mount, such as Kubernetes configMap)
+	export RABBITMQ_CONFIG_FILE='/tmp/rabbitmq.conf'
+	cp "$newConfigFile" "$RABBITMQ_CONFIG_FILE"
+	echo >&2
+	echo >&2 "WARNING: '$newConfigFile' is not writable, but environment variables have been provided which request that we write to it"
+	echo >&2 "  We have copied it to '$RABBITMQ_CONFIG_FILE' so it can be amended to work around the problem, but it is recommended that the read-only source file should be modified and the environment variables removed instead."
+	echo >&2
+	newConfigFile="$RABBITMQ_CONFIG_FILE"
 fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{

--- a/3.7-rc/ubuntu/docker-entrypoint.sh
+++ b/3.7-rc/ubuntu/docker-entrypoint.sh
@@ -202,7 +202,7 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
 	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
 	tmp="/tmp/rabbitmq.conf"
 	cat "$newConfigFile" > "${tmp}"

--- a/3.7-rc/ubuntu/docker-entrypoint.sh
+++ b/3.7-rc/ubuntu/docker-entrypoint.sh
@@ -202,6 +202,13 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
+	tmp="/tmp/rabbitmq.conf"
+	cat "$newConfigFile" > "${tmp}"
+	newConfigFile="${tmp}"
+	export RABBITMQ_CONFIG_FILE="${tmp}"
+fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{
 		echo "error: Docker configuration environment variables specified, but old-style (Erlang syntax) configuration file '$oldConfigFile' exists"

--- a/3.7-rc/ubuntu/docker-entrypoint.sh
+++ b/3.7-rc/ubuntu/docker-entrypoint.sh
@@ -202,12 +202,15 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
-	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
-	tmp="/tmp/rabbitmq.conf"
-	cat "$newConfigFile" > "${tmp}"
-	newConfigFile="${tmp}"
-	export RABBITMQ_CONFIG_FILE="${tmp}"
+if [ -n "$shouldWriteConfig" ] && ! touch "$newConfigFile"; then
+	# config file exists but it isn't writeable (likely read-only mount, such as Kubernetes configMap)
+	export RABBITMQ_CONFIG_FILE='/tmp/rabbitmq.conf'
+	cp "$newConfigFile" "$RABBITMQ_CONFIG_FILE"
+	echo >&2
+	echo >&2 "WARNING: '$newConfigFile' is not writable, but environment variables have been provided which request that we write to it"
+	echo >&2 "  We have copied it to '$RABBITMQ_CONFIG_FILE' so it can be amended to work around the problem, but it is recommended that the read-only source file should be modified and the environment variables removed instead."
+	echo >&2
+	newConfigFile="$RABBITMQ_CONFIG_FILE"
 fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{

--- a/3.7/alpine/docker-entrypoint.sh
+++ b/3.7/alpine/docker-entrypoint.sh
@@ -202,7 +202,7 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
 	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
 	tmp="/tmp/rabbitmq.conf"
 	cat "$newConfigFile" > "${tmp}"

--- a/3.7/alpine/docker-entrypoint.sh
+++ b/3.7/alpine/docker-entrypoint.sh
@@ -202,6 +202,13 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
+	tmp="/tmp/rabbitmq.conf"
+	cat "$newConfigFile" > "${tmp}"
+	newConfigFile="${tmp}"
+	export RABBITMQ_CONFIG_FILE="${tmp}"
+fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{
 		echo "error: Docker configuration environment variables specified, but old-style (Erlang syntax) configuration file '$oldConfigFile' exists"

--- a/3.7/alpine/docker-entrypoint.sh
+++ b/3.7/alpine/docker-entrypoint.sh
@@ -202,12 +202,15 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
-	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
-	tmp="/tmp/rabbitmq.conf"
-	cat "$newConfigFile" > "${tmp}"
-	newConfigFile="${tmp}"
-	export RABBITMQ_CONFIG_FILE="${tmp}"
+if [ -n "$shouldWriteConfig" ] && ! touch "$newConfigFile"; then
+	# config file exists but it isn't writeable (likely read-only mount, such as Kubernetes configMap)
+	export RABBITMQ_CONFIG_FILE='/tmp/rabbitmq.conf'
+	cp "$newConfigFile" "$RABBITMQ_CONFIG_FILE"
+	echo >&2
+	echo >&2 "WARNING: '$newConfigFile' is not writable, but environment variables have been provided which request that we write to it"
+	echo >&2 "  We have copied it to '$RABBITMQ_CONFIG_FILE' so it can be amended to work around the problem, but it is recommended that the read-only source file should be modified and the environment variables removed instead."
+	echo >&2
+	newConfigFile="$RABBITMQ_CONFIG_FILE"
 fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{

--- a/3.7/ubuntu/docker-entrypoint.sh
+++ b/3.7/ubuntu/docker-entrypoint.sh
@@ -202,7 +202,7 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
 	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
 	tmp="/tmp/rabbitmq.conf"
 	cat "$newConfigFile" > "${tmp}"

--- a/3.7/ubuntu/docker-entrypoint.sh
+++ b/3.7/ubuntu/docker-entrypoint.sh
@@ -202,6 +202,13 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
+	tmp="/tmp/rabbitmq.conf"
+	cat "$newConfigFile" > "${tmp}"
+	newConfigFile="${tmp}"
+	export RABBITMQ_CONFIG_FILE="${tmp}"
+fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{
 		echo "error: Docker configuration environment variables specified, but old-style (Erlang syntax) configuration file '$oldConfigFile' exists"

--- a/3.7/ubuntu/docker-entrypoint.sh
+++ b/3.7/ubuntu/docker-entrypoint.sh
@@ -202,12 +202,15 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
-	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
-	tmp="/tmp/rabbitmq.conf"
-	cat "$newConfigFile" > "${tmp}"
-	newConfigFile="${tmp}"
-	export RABBITMQ_CONFIG_FILE="${tmp}"
+if [ -n "$shouldWriteConfig" ] && ! touch "$newConfigFile"; then
+	# config file exists but it isn't writeable (likely read-only mount, such as Kubernetes configMap)
+	export RABBITMQ_CONFIG_FILE='/tmp/rabbitmq.conf'
+	cp "$newConfigFile" "$RABBITMQ_CONFIG_FILE"
+	echo >&2
+	echo >&2 "WARNING: '$newConfigFile' is not writable, but environment variables have been provided which request that we write to it"
+	echo >&2 "  We have copied it to '$RABBITMQ_CONFIG_FILE' so it can be amended to work around the problem, but it is recommended that the read-only source file should be modified and the environment variables removed instead."
+	echo >&2
+	newConfigFile="$RABBITMQ_CONFIG_FILE"
 fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{

--- a/3.8-rc/alpine/docker-entrypoint.sh
+++ b/3.8-rc/alpine/docker-entrypoint.sh
@@ -202,7 +202,7 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
 	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
 	tmp="/tmp/rabbitmq.conf"
 	cat "$newConfigFile" > "${tmp}"

--- a/3.8-rc/alpine/docker-entrypoint.sh
+++ b/3.8-rc/alpine/docker-entrypoint.sh
@@ -202,6 +202,13 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
+	tmp="/tmp/rabbitmq.conf"
+	cat "$newConfigFile" > "${tmp}"
+	newConfigFile="${tmp}"
+	export RABBITMQ_CONFIG_FILE="${tmp}"
+fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{
 		echo "error: Docker configuration environment variables specified, but old-style (Erlang syntax) configuration file '$oldConfigFile' exists"

--- a/3.8-rc/alpine/docker-entrypoint.sh
+++ b/3.8-rc/alpine/docker-entrypoint.sh
@@ -202,12 +202,15 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
-	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
-	tmp="/tmp/rabbitmq.conf"
-	cat "$newConfigFile" > "${tmp}"
-	newConfigFile="${tmp}"
-	export RABBITMQ_CONFIG_FILE="${tmp}"
+if [ -n "$shouldWriteConfig" ] && ! touch "$newConfigFile"; then
+	# config file exists but it isn't writeable (likely read-only mount, such as Kubernetes configMap)
+	export RABBITMQ_CONFIG_FILE='/tmp/rabbitmq.conf'
+	cp "$newConfigFile" "$RABBITMQ_CONFIG_FILE"
+	echo >&2
+	echo >&2 "WARNING: '$newConfigFile' is not writable, but environment variables have been provided which request that we write to it"
+	echo >&2 "  We have copied it to '$RABBITMQ_CONFIG_FILE' so it can be amended to work around the problem, but it is recommended that the read-only source file should be modified and the environment variables removed instead."
+	echo >&2
+	newConfigFile="$RABBITMQ_CONFIG_FILE"
 fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{

--- a/3.8-rc/ubuntu/docker-entrypoint.sh
+++ b/3.8-rc/ubuntu/docker-entrypoint.sh
@@ -202,7 +202,7 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
 	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
 	tmp="/tmp/rabbitmq.conf"
 	cat "$newConfigFile" > "${tmp}"

--- a/3.8-rc/ubuntu/docker-entrypoint.sh
+++ b/3.8-rc/ubuntu/docker-entrypoint.sh
@@ -202,6 +202,13 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
+	tmp="/tmp/rabbitmq.conf"
+	cat "$newConfigFile" > "${tmp}"
+	newConfigFile="${tmp}"
+	export RABBITMQ_CONFIG_FILE="${tmp}"
+fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{
 		echo "error: Docker configuration environment variables specified, but old-style (Erlang syntax) configuration file '$oldConfigFile' exists"

--- a/3.8-rc/ubuntu/docker-entrypoint.sh
+++ b/3.8-rc/ubuntu/docker-entrypoint.sh
@@ -202,12 +202,15 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
-	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
-	tmp="/tmp/rabbitmq.conf"
-	cat "$newConfigFile" > "${tmp}"
-	newConfigFile="${tmp}"
-	export RABBITMQ_CONFIG_FILE="${tmp}"
+if [ -n "$shouldWriteConfig" ] && ! touch "$newConfigFile"; then
+	# config file exists but it isn't writeable (likely read-only mount, such as Kubernetes configMap)
+	export RABBITMQ_CONFIG_FILE='/tmp/rabbitmq.conf'
+	cp "$newConfigFile" "$RABBITMQ_CONFIG_FILE"
+	echo >&2
+	echo >&2 "WARNING: '$newConfigFile' is not writable, but environment variables have been provided which request that we write to it"
+	echo >&2 "  We have copied it to '$RABBITMQ_CONFIG_FILE' so it can be amended to work around the problem, but it is recommended that the read-only source file should be modified and the environment variables removed instead."
+	echo >&2
+	newConfigFile="$RABBITMQ_CONFIG_FILE"
 fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -202,7 +202,7 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
 	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
 	tmp="/tmp/rabbitmq.conf"
 	cat "$newConfigFile" > "${tmp}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -202,6 +202,13 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
+if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && [ ! -w "$newConfigFile" ]; then
+	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
+	tmp="/tmp/rabbitmq.conf"
+	cat "$newConfigFile" > "${tmp}"
+	newConfigFile="${tmp}"
+	export RABBITMQ_CONFIG_FILE="${tmp}"
+fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{
 		echo "error: Docker configuration environment variables specified, but old-style (Erlang syntax) configuration file '$oldConfigFile' exists"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -202,12 +202,15 @@ oldConfigFile="$configBase.config"
 newConfigFile="$configBase.conf"
 
 shouldWriteConfig="$haveConfig"
-if [ -n "$shouldWriteConfig" ] && [ -f "$newConfigFile" ] && { [ ! -w "$newConfigFile" ] || [ "$(grep -sq "$newConfigFile" /proc/mounts; echo $?)" -eq 0 ]; }; then
-	# config file exist but it isn't writeable (e.g. Kubernetes v1.9.4+ configMap mount)
-	tmp="/tmp/rabbitmq.conf"
-	cat "$newConfigFile" > "${tmp}"
-	newConfigFile="${tmp}"
-	export RABBITMQ_CONFIG_FILE="${tmp}"
+if [ -n "$shouldWriteConfig" ] && ! touch "$newConfigFile"; then
+	# config file exists but it isn't writeable (likely read-only mount, such as Kubernetes configMap)
+	export RABBITMQ_CONFIG_FILE='/tmp/rabbitmq.conf'
+	cp "$newConfigFile" "$RABBITMQ_CONFIG_FILE"
+	echo >&2
+	echo >&2 "WARNING: '$newConfigFile' is not writable, but environment variables have been provided which request that we write to it"
+	echo >&2 "  We have copied it to '$RABBITMQ_CONFIG_FILE' so it can be amended to work around the problem, but it is recommended that the read-only source file should be modified and the environment variables removed instead."
+	echo >&2
+	newConfigFile="$RABBITMQ_CONFIG_FILE"
 fi
 if [ -n "$shouldWriteConfig" ] && [ -f "$oldConfigFile" ]; then
 	{


### PR DESCRIPTION
This is a pretty common use-case given that as of Kubernetes v1.9.4 configMaps are mounted as read-only. See #368 for more details.

Consider this PR as a suggestion for one potential fix. There are probably other ways to address this. I'm not too set on how we address it as long as we do so in the docker image. 😊

Fixes #368