### PR TITLE
Switch from "management.listener.ssl_opts" to "management.ssl"

### DIFF
--- a/3.7-rc/alpine/docker-entrypoint.sh
+++ b/3.7-rc/alpine/docker-entrypoint.sh
@@ -260,7 +260,7 @@ rabbit_env_config() {
 		local key="$conf"
 		case "$prefix" in
 			ssl) key="ssl_options.$key" ;;
-			management_ssl) key="management.listener.ssl_opts.$key" ;;
+			management_ssl) key="management.ssl.$key" ;;
 		esac
 
 		local val="${!var:-}"
@@ -366,12 +366,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	# https://www.rabbitmq.com/management.html#configuration
 	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
 		if [ "$haveManagementSslConfig" ]; then
-			rabbit_set_config 'management.listener.port' 15671
-			rabbit_set_config 'management.listener.ssl' 'true'
+			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"
 		else
-			rabbit_set_config 'management.listener.port' 15672
-			rabbit_set_config 'management.listener.ssl' 'false'
+			rabbit_set_config 'management.tcp.port' 15672
 		fi
 
 		# if definitions file exists, then load it

--- a/3.7-rc/ubuntu/docker-entrypoint.sh
+++ b/3.7-rc/ubuntu/docker-entrypoint.sh
@@ -260,7 +260,7 @@ rabbit_env_config() {
 		local key="$conf"
 		case "$prefix" in
 			ssl) key="ssl_options.$key" ;;
-			management_ssl) key="management.listener.ssl_opts.$key" ;;
+			management_ssl) key="management.ssl.$key" ;;
 		esac
 
 		local val="${!var:-}"
@@ -366,12 +366,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	# https://www.rabbitmq.com/management.html#configuration
 	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
 		if [ "$haveManagementSslConfig" ]; then
-			rabbit_set_config 'management.listener.port' 15671
-			rabbit_set_config 'management.listener.ssl' 'true'
+			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"
 		else
-			rabbit_set_config 'management.listener.port' 15672
-			rabbit_set_config 'management.listener.ssl' 'false'
+			rabbit_set_config 'management.tcp.port' 15672
 		fi
 
 		# if definitions file exists, then load it

--- a/3.7/alpine/docker-entrypoint.sh
+++ b/3.7/alpine/docker-entrypoint.sh
@@ -260,7 +260,7 @@ rabbit_env_config() {
 		local key="$conf"
 		case "$prefix" in
 			ssl) key="ssl_options.$key" ;;
-			management_ssl) key="management.listener.ssl_opts.$key" ;;
+			management_ssl) key="management.ssl.$key" ;;
 		esac
 
 		local val="${!var:-}"
@@ -366,12 +366,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	# https://www.rabbitmq.com/management.html#configuration
 	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
 		if [ "$haveManagementSslConfig" ]; then
-			rabbit_set_config 'management.listener.port' 15671
-			rabbit_set_config 'management.listener.ssl' 'true'
+			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"
 		else
-			rabbit_set_config 'management.listener.port' 15672
-			rabbit_set_config 'management.listener.ssl' 'false'
+			rabbit_set_config 'management.tcp.port' 15672
 		fi
 
 		# if definitions file exists, then load it

--- a/3.7/ubuntu/docker-entrypoint.sh
+++ b/3.7/ubuntu/docker-entrypoint.sh
@@ -260,7 +260,7 @@ rabbit_env_config() {
 		local key="$conf"
 		case "$prefix" in
 			ssl) key="ssl_options.$key" ;;
-			management_ssl) key="management.listener.ssl_opts.$key" ;;
+			management_ssl) key="management.ssl.$key" ;;
 		esac
 
 		local val="${!var:-}"
@@ -366,12 +366,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	# https://www.rabbitmq.com/management.html#configuration
 	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
 		if [ "$haveManagementSslConfig" ]; then
-			rabbit_set_config 'management.listener.port' 15671
-			rabbit_set_config 'management.listener.ssl' 'true'
+			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"
 		else
-			rabbit_set_config 'management.listener.port' 15672
-			rabbit_set_config 'management.listener.ssl' 'false'
+			rabbit_set_config 'management.tcp.port' 15672
 		fi
 
 		# if definitions file exists, then load it

--- a/3.8-rc/alpine/docker-entrypoint.sh
+++ b/3.8-rc/alpine/docker-entrypoint.sh
@@ -260,7 +260,7 @@ rabbit_env_config() {
 		local key="$conf"
 		case "$prefix" in
 			ssl) key="ssl_options.$key" ;;
-			management_ssl) key="management.listener.ssl_opts.$key" ;;
+			management_ssl) key="management.ssl.$key" ;;
 		esac
 
 		local val="${!var:-}"
@@ -366,12 +366,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	# https://www.rabbitmq.com/management.html#configuration
 	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
 		if [ "$haveManagementSslConfig" ]; then
-			rabbit_set_config 'management.listener.port' 15671
-			rabbit_set_config 'management.listener.ssl' 'true'
+			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"
 		else
-			rabbit_set_config 'management.listener.port' 15672
-			rabbit_set_config 'management.listener.ssl' 'false'
+			rabbit_set_config 'management.tcp.port' 15672
 		fi
 
 		# if definitions file exists, then load it

--- a/3.8-rc/ubuntu/docker-entrypoint.sh
+++ b/3.8-rc/ubuntu/docker-entrypoint.sh
@@ -260,7 +260,7 @@ rabbit_env_config() {
 		local key="$conf"
 		case "$prefix" in
 			ssl) key="ssl_options.$key" ;;
-			management_ssl) key="management.listener.ssl_opts.$key" ;;
+			management_ssl) key="management.ssl.$key" ;;
 		esac
 
 		local val="${!var:-}"
@@ -366,12 +366,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	# https://www.rabbitmq.com/management.html#configuration
 	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
 		if [ "$haveManagementSslConfig" ]; then
-			rabbit_set_config 'management.listener.port' 15671
-			rabbit_set_config 'management.listener.ssl' 'true'
+			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"
 		else
-			rabbit_set_config 'management.listener.port' 15672
-			rabbit_set_config 'management.listener.ssl' 'false'
+			rabbit_set_config 'management.tcp.port' 15672
 		fi
 
 		# if definitions file exists, then load it

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -260,7 +260,7 @@ rabbit_env_config() {
 		local key="$conf"
 		case "$prefix" in
 			ssl) key="ssl_options.$key" ;;
-			management_ssl) key="management.listener.ssl_opts.$key" ;;
+			management_ssl) key="management.ssl.$key" ;;
 		esac
 
 		local val="${!var:-}"
@@ -366,12 +366,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 	# https://www.rabbitmq.com/management.html#configuration
 	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
 		if [ "$haveManagementSslConfig" ]; then
-			rabbit_set_config 'management.listener.port' 15671
-			rabbit_set_config 'management.listener.ssl' 'true'
+			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"
 		else
-			rabbit_set_config 'management.listener.port' 15672
-			rabbit_set_config 'management.listener.ssl' 'false'
+			rabbit_set_config 'management.tcp.port' 15672
 		fi
 
 		# if definitions file exists, then load it


### PR DESCRIPTION
From #367:

> This image provisions the latest RabbitMQ but still uses legacy (pre-3.7.9, soon to be 1 year old) settings to configure HTTP(S) API's [TCP and TLS settings](https://www.rabbitmq.com/management.html#multiple-listeners): `management.listener.*` specifically.
> ...
> They are consistent with the core listener settings and easier to remember. They also make it possible to configure both HTTP and HTTPS listeners side by side which was not possible with a single set of options  (`management.listener.*`).

Fixes #367