### PR TITLE
Commented out EXPOSE instructions to allow cloudfoundry apps to define their own where only one port is supported

### DIFF
--- a/3.7-rc/alpine/Dockerfile
+++ b/3.7-rc/alpine/Dockerfile
@@ -248,5 +248,5 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 4369 5671 5672 25672
+#EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]

--- a/3.7-rc/alpine/management/Dockerfile
+++ b/3.7-rc/alpine/management/Dockerfile
@@ -24,4 +24,4 @@ RUN set -eux; \
 	apk add --no-cache python; \
 	rabbitmqadmin --version
 
-EXPOSE 15671 15672
+#EXPOSE 15671 15672

--- a/3.7-rc/ubuntu/Dockerfile
+++ b/3.7-rc/ubuntu/Dockerfile
@@ -264,5 +264,5 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 4369 5671 5672 25672
+#EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]

--- a/3.7-rc/ubuntu/management/Dockerfile
+++ b/3.7-rc/ubuntu/management/Dockerfile
@@ -24,4 +24,4 @@ RUN set -eux; \
 	apt-get update; apt-get install -y --no-install-recommends python; rm -rf /var/lib/apt/lists/*; \
 	rabbitmqadmin --version
 
-EXPOSE 15671 15672
+#EXPOSE 15671 15672

--- a/3.7/alpine/Dockerfile
+++ b/3.7/alpine/Dockerfile
@@ -248,5 +248,5 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 4369 5671 5672 25672
+#EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]

--- a/3.7/alpine/management/Dockerfile
+++ b/3.7/alpine/management/Dockerfile
@@ -24,4 +24,4 @@ RUN set -eux; \
 	apk add --no-cache python; \
 	rabbitmqadmin --version
 
-EXPOSE 15671 15672
+#EXPOSE 15671 15672

--- a/3.7/ubuntu/Dockerfile
+++ b/3.7/ubuntu/Dockerfile
@@ -264,5 +264,5 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 4369 5671 5672 25672
+#EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]

--- a/3.7/ubuntu/management/Dockerfile
+++ b/3.7/ubuntu/management/Dockerfile
@@ -24,4 +24,4 @@ RUN set -eux; \
 	apt-get update; apt-get install -y --no-install-recommends python; rm -rf /var/lib/apt/lists/*; \
 	rabbitmqadmin --version
 
-EXPOSE 15671 15672
+#EXPOSE 15671 15672

--- a/3.8-rc/alpine/Dockerfile
+++ b/3.8-rc/alpine/Dockerfile
@@ -248,5 +248,5 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 4369 5671 5672 25672
+#EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]

--- a/3.8-rc/alpine/management/Dockerfile
+++ b/3.8-rc/alpine/management/Dockerfile
@@ -24,4 +24,4 @@ RUN set -eux; \
 	apk add --no-cache python; \
 	rabbitmqadmin --version
 
-EXPOSE 15671 15672
+#EXPOSE 15671 15672

--- a/3.8-rc/ubuntu/Dockerfile
+++ b/3.8-rc/ubuntu/Dockerfile
@@ -264,5 +264,5 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 4369 5671 5672 25672
+#EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]

--- a/3.8-rc/ubuntu/management/Dockerfile
+++ b/3.8-rc/ubuntu/management/Dockerfile
@@ -24,4 +24,4 @@ RUN set -eux; \
 	apt-get update; apt-get install -y --no-install-recommends python; rm -rf /var/lib/apt/lists/*; \
 	rabbitmqadmin --version
 
-EXPOSE 15671 15672
+#EXPOSE 15671 15672

--- a/3.8/alpine/Dockerfile
+++ b/3.8/alpine/Dockerfile
@@ -248,5 +248,5 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 4369 5671 5672 25672
+#EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]

--- a/3.8/alpine/management/Dockerfile
+++ b/3.8/alpine/management/Dockerfile
@@ -24,4 +24,4 @@ RUN set -eux; \
 	apk add --no-cache python; \
 	rabbitmqadmin --version
 
-EXPOSE 15671 15672
+#EXPOSE 15671 15672

--- a/3.8/ubuntu/Dockerfile
+++ b/3.8/ubuntu/Dockerfile
@@ -264,5 +264,5 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 4369 5671 5672 25672
+#EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]

--- a/3.8/ubuntu/management/Dockerfile
+++ b/3.8/ubuntu/management/Dockerfile
@@ -24,4 +24,4 @@ RUN set -eux; \
 	apt-get update; apt-get install -y --no-install-recommends python; rm -rf /var/lib/apt/lists/*; \
 	rabbitmqadmin --version
 
-EXPOSE 15671 15672
+#EXPOSE 15671 15672

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -248,5 +248,5 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 4369 5671 5672 25672
+#EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]

--- a/Dockerfile-management.template
+++ b/Dockerfile-management.template
@@ -24,4 +24,4 @@ RUN set -eux; \
 	%%INSTALL_PYTHON%%; \
 	rabbitmqadmin --version
 
-EXPOSE 15671 15672
+#EXPOSE 15671 15672

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -264,5 +264,5 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 4369 5671 5672 25672
+#EXPOSE 4369 5671 5672 25672
 CMD ["rabbitmq-server"]


### PR DESCRIPTION
> Cloud Foundry supports only one exposed port on the image. https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html#port-configuration

> Reset properties inherited from parent image · Issue #3465 · moby/moby
https://github.com/moby/moby/issues/3465
