### PR TITLE
Remove RABBITMQ_SASL_LOGS variable

### DIFF
--- a/3.7-rc/alpine/Dockerfile
+++ b/3.7-rc/alpine/Dockerfile
@@ -188,7 +188,7 @@ ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
+	RABBITMQ_LOGS=-
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.7-rc/ubuntu/Dockerfile
+++ b/3.7-rc/ubuntu/Dockerfile
@@ -198,7 +198,7 @@ ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
+	RABBITMQ_LOGS=-
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.7/alpine/Dockerfile
+++ b/3.7/alpine/Dockerfile
@@ -188,7 +188,7 @@ ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
+	RABBITMQ_LOGS=-
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.7/ubuntu/Dockerfile
+++ b/3.7/ubuntu/Dockerfile
@@ -198,7 +198,7 @@ ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
+	RABBITMQ_LOGS=-
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.8-rc/alpine/Dockerfile
+++ b/3.8-rc/alpine/Dockerfile
@@ -188,7 +188,7 @@ ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
+	RABBITMQ_LOGS=-
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.8-rc/ubuntu/Dockerfile
+++ b/3.8-rc/ubuntu/Dockerfile
@@ -198,7 +198,7 @@ ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
+	RABBITMQ_LOGS=-
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.8/alpine/Dockerfile
+++ b/3.8/alpine/Dockerfile
@@ -188,7 +188,7 @@ ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
+	RABBITMQ_LOGS=-
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.8/ubuntu/Dockerfile
+++ b/3.8/ubuntu/Dockerfile
@@ -198,7 +198,7 @@ ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
+	RABBITMQ_LOGS=-
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -188,7 +188,7 @@ ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
+	RABBITMQ_LOGS=-
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -198,7 +198,7 @@ ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=- RABBITMQ_SASL_LOGS=-
+	RABBITMQ_LOGS=-
 
 # Install RabbitMQ
 RUN set -eux; \


### PR DESCRIPTION
Starting with 3.7.0 these two files were merged and all errors now can
be found in the <nodename>.log file. So RABBITMQ_SASL_LOGS environment
variable is not used anymore.

ref: https://www.rabbitmq.com/logging.html#upgrading

cc @michaelklishin 