### PR TITLE
Use Python 3 explicitly for rabbitmqadmin in Ubuntu

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -119,6 +119,15 @@ for version in "${versions[@]}"; do
 	fi
 	opensslSourceSha256="$(wget -qO- "https://www.openssl.org/source/openssl-$opensslVersion.tar.gz.sha256")"
 
+# https://github.com/rabbitmq/rabbitmq-management/issues/786
+	python='python3'
+	case "$fullVersion" in
+		3.7.24* | 3.8.3*)
+			# TODO delete after these versions are gone
+			python='python'
+			;;
+	esac
+
 	echo "$version: $fullVersion"
 
 	for variant in alpine ubuntu; do
@@ -136,10 +145,10 @@ for version in "${versions[@]}"; do
 		cp -a docker-entrypoint.sh "$version/$variant/"
 
 		managementFrom="rabbitmq:$version"
-		installPython='apt-get update; apt-get install -y --no-install-recommends python; rm -rf /var/lib/apt/lists/*'
+		installPython='apt-get update; apt-get install -y --no-install-recommends '"$python"'; rm -rf /var/lib/apt/lists/*'
 		if [ "$variant" = 'alpine' ]; then
 			managementFrom+='-alpine'
-			installPython='apk add --no-cache python'
+			installPython="apk add --no-cache $python"
 			sed -i 's/gosu/su-exec/g' "$version/$variant/docker-entrypoint.sh"
 		fi
 		sed -e "s!%%FROM%%!$managementFrom!g" \


### PR DESCRIPTION
This may impact the Alpine variant as well, but I haven't checked.

Plain python defaults to v2 & it fails with:

```
... (elided for brevity, see the commit message for full context) ...
  + rabbitmqadmin --version
  /usr/bin/env: ‘python3’: No such file or directory
  The command '/bin/sh -c set -eux; 	erl -noinput -eval ' 		{ ok, AdminBin } = zip:foldl(fun(FileInArchive, GetInfo, GetBin, Acc) -> 			case Acc of 				"" -> 					case lists:suffix("/rabbitmqadmin", FileInArchive) of 						true -> GetBin(); 						false -> Acc 					end; 				_ -> Acc 			end 		end, "", init:get_plain_arguments()), 		io:format("~s", [ AdminBin ]), 		init:stop(). 	' -- /plugins/rabbitmq_management-*.ez > /usr/local/bin/rabbitmqadmin; 	[ -s /usr/local/bin/rabbitmqadmin ]; 	chmod +x /usr/local/bin/rabbitmqadmin; 	apt-get update; apt-get install -y --no-install-recommends python; rm -rf /var/lib/apt/lists/*; 	rabbitmqadmin --version' returned a non-zero code: 127
  make: *** [Makefile:360: docker-image] Error 127
```