### PR TITLE
Introduce a variant without the VOLUME declaration

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -237,8 +237,6 @@ RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
 ENV HOME $RABBITMQ_DATA_DIR
-# Hint that the data (a.k.a. home dir) dir should be separate volume
-VOLUME $RABBITMQ_DATA_DIR
 
 # warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell)
 # Setting all environment variables that control language preferences, behaviour differs - https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html#The-LANGUAGE-variable

--- a/Dockerfile-management.template
+++ b/Dockerfile-management.template
@@ -25,3 +25,6 @@ RUN set -eux; \
 	rabbitmqadmin --version
 
 EXPOSE 15671 15672
+
+# Hint that the data (a.k.a. home dir) dir should be separate volume
+VOLUME $RABBITMQ_DATA_DIR

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -253,8 +253,6 @@ RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
 ENV HOME $RABBITMQ_DATA_DIR
-# Hint that the data (a.k.a. home dir) dir should be separate volume
-VOLUME $RABBITMQ_DATA_DIR
 
 # warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell)
 # Setting all environment variables that control language preferences, behaviour differs - https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html#The-LANGUAGE-variable

--- a/Dockerfile-volume.template
+++ b/Dockerfile-volume.template
@@ -1,0 +1,4 @@
+FROM %%FROM%%
+
+# Hint that the data (a.k.a. home dir) dir should be separate volume
+VOLUME $RABBITMQ_DATA_DIR

--- a/update.sh
+++ b/update.sh
@@ -139,11 +139,16 @@ for version in "${versions[@]}"; do
 			-e "s!%%OTP_SOURCE_SHA256%%!$otpSourceSha256!g" \
 			-e "s!%%RABBITMQ_VERSION%%!$fullVersion!g" \
 			"Dockerfile-$variant.template" \
+			> "$version/$variant/volumeless/Dockerfile"
+
+		cp -a docker-entrypoint.sh "$version/$variant/volumeless/"
+
+		standardFrom="rabbitmq:$version-volumeless"
+		sed -e "s!%%FROM%%!$standardFrom!g" \
+			Dockerfile-volume.template \
 			> "$version/$variant/Dockerfile"
 
-		cp -a docker-entrypoint.sh "$version/$variant/"
-
-		managementFrom="rabbitmq:$version"
+		managementFrom="rabbitmq:$version-volumeless"
 		installPython='apt-get update; apt-get install -y --no-install-recommends '"$python"'; rm -rf /var/lib/apt/lists/*'
 		if [ "$variant" = 'alpine' ]; then
 			managementFrom+='-alpine'


### PR DESCRIPTION
While ideal in most cases, the inclusion of the VOLUME prevents further modification of the RABBITMQ_DATA_DIR by derivative Dockerfiles. This is an attempt at the lightest weight option for maintaining the behavior of the existing images, but providing flexibility when necessary.