### PR TITLE
Update to alpine:3.12

### DIFF
--- a/3.7-rc/alpine/Dockerfile
+++ b/3.7-rc/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN apk add --no-cache \
 # grab su-exec for easy step-down from root
@@ -37,7 +37,6 @@ RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		autoconf \
-		ca-certificates \
 		dpkg-dev dpkg \
 		gcc \
 		gnupg \
@@ -194,7 +193,6 @@ ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gnupg \
 		xz \
 	; \

--- a/3.7/alpine/Dockerfile
+++ b/3.7/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN apk add --no-cache \
 # grab su-exec for easy step-down from root
@@ -37,7 +37,6 @@ RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		autoconf \
-		ca-certificates \
 		dpkg-dev dpkg \
 		gcc \
 		gnupg \
@@ -194,7 +193,6 @@ ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gnupg \
 		xz \
 	; \

--- a/3.8-rc/alpine/Dockerfile
+++ b/3.8-rc/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN apk add --no-cache \
 # grab su-exec for easy step-down from root
@@ -37,7 +37,6 @@ RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		autoconf \
-		ca-certificates \
 		dpkg-dev dpkg \
 		gcc \
 		gnupg \
@@ -194,7 +193,6 @@ ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gnupg \
 		xz \
 	; \

--- a/3.8/alpine/Dockerfile
+++ b/3.8/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN apk add --no-cache \
 # grab su-exec for easy step-down from root
@@ -37,7 +37,6 @@ RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		autoconf \
-		ca-certificates \
 		dpkg-dev dpkg \
 		gcc \
 		gnupg \
@@ -194,7 +193,6 @@ ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gnupg \
 		xz \
 	; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,5 +1,5 @@
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN apk add --no-cache \
 # grab su-exec for easy step-down from root
@@ -37,7 +37,6 @@ RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		autoconf \
-		ca-certificates \
 		dpkg-dev dpkg \
 		gcc \
 		gnupg \
@@ -194,7 +193,6 @@ ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gnupg \
 		xz \
 	; \


### PR DESCRIPTION
Also, Alpine includes `/etc/ssl/cert.pem` bundle, so `ca-certificates` is unnecessary

Fixes #420