### PR TITLE
Use load_definitions instead of management.load_definitions

### DIFF
--- a/3.8-rc/alpine/docker-entrypoint.sh
+++ b/3.8-rc/alpine/docker-entrypoint.sh
@@ -386,8 +386,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 		# https://www.rabbitmq.com/management.html#load-definitions
 		managementDefinitionsFile='/etc/rabbitmq/definitions.json'
 		if [ -f "$managementDefinitionsFile" ]; then
-			# see also https://github.com/docker-library/rabbitmq/pull/112#issuecomment-271485550
-			rabbit_set_config 'management.load_definitions' "$managementDefinitionsFile"
+			# We use `load_definitions` (the built-in setting as of 3.8.2+) instead
+			# of `management.load_definitions`.
+			# See https://github.com/docker-library/rabbitmq/issues/429 for details.
+			rabbit_set_config 'load_definitions' "$managementDefinitionsFile"
 		fi
 	fi
 fi

--- a/3.8-rc/ubuntu/docker-entrypoint.sh
+++ b/3.8-rc/ubuntu/docker-entrypoint.sh
@@ -386,8 +386,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 		# https://www.rabbitmq.com/management.html#load-definitions
 		managementDefinitionsFile='/etc/rabbitmq/definitions.json'
 		if [ -f "$managementDefinitionsFile" ]; then
-			# see also https://github.com/docker-library/rabbitmq/pull/112#issuecomment-271485550
-			rabbit_set_config 'management.load_definitions' "$managementDefinitionsFile"
+			# We use `load_definitions` (the built-in setting as of 3.8.2+) instead
+			# of `management.load_definitions`.
+			# See https://github.com/docker-library/rabbitmq/issues/429 for details.
+			rabbit_set_config 'load_definitions' "$managementDefinitionsFile"
 		fi
 	fi
 fi

--- a/3.8/alpine/docker-entrypoint.sh
+++ b/3.8/alpine/docker-entrypoint.sh
@@ -386,8 +386,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 		# https://www.rabbitmq.com/management.html#load-definitions
 		managementDefinitionsFile='/etc/rabbitmq/definitions.json'
 		if [ -f "$managementDefinitionsFile" ]; then
-			# see also https://github.com/docker-library/rabbitmq/pull/112#issuecomment-271485550
-			rabbit_set_config 'management.load_definitions' "$managementDefinitionsFile"
+			# We use `load_definitions` (the built-in setting as of 3.8.2+) instead
+			# of `management.load_definitions`.
+			# See https://github.com/docker-library/rabbitmq/issues/429 for details.
+			rabbit_set_config 'load_definitions' "$managementDefinitionsFile"
 		fi
 	fi
 fi

--- a/3.8/ubuntu/docker-entrypoint.sh
+++ b/3.8/ubuntu/docker-entrypoint.sh
@@ -386,8 +386,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 		# https://www.rabbitmq.com/management.html#load-definitions
 		managementDefinitionsFile='/etc/rabbitmq/definitions.json'
 		if [ -f "$managementDefinitionsFile" ]; then
-			# see also https://github.com/docker-library/rabbitmq/pull/112#issuecomment-271485550
-			rabbit_set_config 'management.load_definitions' "$managementDefinitionsFile"
+			# We use `load_definitions` (the built-in setting as of 3.8.2+) instead
+			# of `management.load_definitions`.
+			# See https://github.com/docker-library/rabbitmq/issues/429 for details.
+			rabbit_set_config 'load_definitions' "$managementDefinitionsFile"
 		fi
 	fi
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -386,8 +386,10 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 		# https://www.rabbitmq.com/management.html#load-definitions
 		managementDefinitionsFile='/etc/rabbitmq/definitions.json'
 		if [ -f "$managementDefinitionsFile" ]; then
-			# see also https://github.com/docker-library/rabbitmq/pull/112#issuecomment-271485550
-			rabbit_set_config 'management.load_definitions' "$managementDefinitionsFile"
+			# We use `load_definitions` (the built-in setting as of 3.8.2+) instead
+			# of `management.load_definitions`.
+			# See https://github.com/docker-library/rabbitmq/issues/429 for details.
+			rabbit_set_config 'load_definitions' "$managementDefinitionsFile"
 		fi
 	fi
 fi


### PR DESCRIPTION
See #429 for the explanation of what the difference is and why this image should use the newer core mechanism (and not the original management plugin feature).

Closes #429.