### PR TITLE
DEV-1750: tomo_upgrade_rmq

### DIFF
--- a/3.8-rc/alpine/Dockerfile
+++ b/3.8-rc/alpine/Dockerfile
@@ -7,6 +7,9 @@
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
 FROM alpine:3.13
 
+ARG USER_ID
+ARG GROUP_ID
+
 RUN apk add --no-cache \
 # grab su-exec for easy step-down from root
 		'su-exec>=0.2' \
@@ -176,8 +179,8 @@ RUN set -eux; \
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 # Create rabbitmq system user & group, fix permissions & allow root user to connect to the RabbitMQ Erlang VM
 RUN set -eux; \
-	addgroup -g 101 -S rabbitmq; \
-	adduser -u 100 -S -h "$RABBITMQ_DATA_DIR" -G rabbitmq rabbitmq; \
+	addgroup -g ${GROUP_ID:-101} -S rabbitmq; \
+	adduser -u ${USER_ID:-100} -S -h "$RABBITMQ_DATA_DIR" -G rabbitmq rabbitmq; \
 	mkdir -p "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chown -fR rabbitmq:rabbitmq "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chmod 777 "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \

--- a/3.8-rc/alpine/management/Dockerfile
+++ b/3.8-rc/alpine/management/Dockerfile
@@ -8,6 +8,9 @@ FROM optimoroute/rabbitmq:3.8-rc-alpine
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
 
+# Add management agent to the image
+RUN rabbitmq-plugins enable --offline rabbitmq_management_agent
+
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 RUN rm -f /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 

--- a/3.8-rc/alpine/management/Dockerfile
+++ b/3.8-rc/alpine/management/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM rabbitmq:3.8-rc-alpine
+FROM optimoroute/rabbitmq:3.8-rc-alpine
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
 

--- a/3.8-rc/ubuntu/Dockerfile
+++ b/3.8-rc/ubuntu/Dockerfile
@@ -260,6 +260,9 @@ RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_prometheus; \
 	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 
+# add support for the federation
+RUN rabbitmq-plugins enable --offline rabbitmq_federation rabbitmq_federation_management
+
 # Added for backwards compatibility - users can simply COPY custom plugins to /plugins
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
@@ -275,6 +278,10 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
+
+ADD setup-server.sh /
+RUN chmod a+x /setup-server.sh
+/setup-server.sh &
 
 EXPOSE 4369 5671 5672 15691 15692 25672
 # Port range RabbitMQ will use for interprocess communication

--- a/3.8-rc/ubuntu/Dockerfile
+++ b/3.8-rc/ubuntu/Dockerfile
@@ -8,6 +8,9 @@
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:18.04
 
+ARG USER_ID
+ARG GROUP_ID
+
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -187,8 +190,8 @@ RUN set -eux; \
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 # Create rabbitmq system user & group, fix permissions & allow root user to connect to the RabbitMQ Erlang VM
 RUN set -eux; \
-	groupadd --gid 999 --system rabbitmq; \
-	useradd --uid 999 --system --home-dir "$RABBITMQ_DATA_DIR" --gid rabbitmq rabbitmq; \
+	groupadd --gid ${GROUP_ID:-999} --system rabbitmq; \
+	useradd --uid ${USER_ID:-999} --system --home-dir "$RABBITMQ_DATA_DIR" --gid rabbitmq rabbitmq; \
 	mkdir -p "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chown -fR rabbitmq:rabbitmq "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chmod 777 "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
@@ -274,4 +277,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 4369 5671 5672 15691 15692 25672
+# Port range RabbitMQ will use for interprocess communication
+EXPOSE 9100 9101 9102 9103 9104 9105
 CMD ["rabbitmq-server"]

--- a/3.8-rc/ubuntu/management/Dockerfile
+++ b/3.8-rc/ubuntu/management/Dockerfile
@@ -8,6 +8,9 @@ FROM optimoroute/rabbitmq:3.8-rc
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
 
+# Add management agent to the image
+RUN rabbitmq-plugins enable --offline rabbitmq_management_agent
+
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 RUN rm -f /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 

--- a/3.8-rc/ubuntu/management/Dockerfile
+++ b/3.8-rc/ubuntu/management/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM rabbitmq:3.8-rc
+FROM optimoroute/rabbitmq:3.8-rc
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
 

--- a/3.8/alpine/Dockerfile
+++ b/3.8/alpine/Dockerfile
@@ -7,6 +7,9 @@
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
 FROM alpine:3.13
 
+ARG USER_ID
+ARG GROUP_ID
+
 RUN apk add --no-cache \
 # grab su-exec for easy step-down from root
 		'su-exec>=0.2' \
@@ -176,8 +179,8 @@ RUN set -eux; \
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 # Create rabbitmq system user & group, fix permissions & allow root user to connect to the RabbitMQ Erlang VM
 RUN set -eux; \
-	addgroup -g 101 -S rabbitmq; \
-	adduser -u 100 -S -h "$RABBITMQ_DATA_DIR" -G rabbitmq rabbitmq; \
+	addgroup -g ${GROUP_ID:-101} -S rabbitmq; \
+	adduser -u ${USER_ID:-100} -S -h "$RABBITMQ_DATA_DIR" -G rabbitmq rabbitmq; \
 	mkdir -p "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chown -fR rabbitmq:rabbitmq "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chmod 777 "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \

--- a/3.8/alpine/management/Dockerfile
+++ b/3.8/alpine/management/Dockerfile
@@ -8,6 +8,9 @@ FROM optimoroute/rabbitmq:3.8-alpine
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
 
+# Add management agent to the image
+RUN rabbitmq-plugins enable --offline rabbitmq_management_agent
+
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 RUN rm -f /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 

--- a/3.8/alpine/management/Dockerfile
+++ b/3.8/alpine/management/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM rabbitmq:3.8-alpine
+FROM optimoroute/rabbitmq:3.8-alpine
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
 

--- a/3.8/alpine/setup-server.sh
+++ b/3.8/alpine/setup-server.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+while true
+do
+  rabbitmq-diagnostics check_running > /dev/null 2>&1
+  verifier=$?
+  if [[ $verifier == 0 ]]
+    then
+      if [[ -n $CLUSTER_WITH ]]; then
+          rabbitmqctl stop_app
+          if [[ -z $RAM_NODE ]]; then
+            rabbitmqctl join_cluster rabbit@"$CLUSTER_WITH"
+          else
+            rabbitmqctl join_cluster --ram rabbit@"$CLUSTER_WITH"
+          fi
+          rabbitmqctl start_app
+
+        if [[ -n $RABBITMQ_POLICY_HA_ALL ]]; then
+          rabbitmqctl set_policy ha-all "^(?!amq\.).*" '{"ha-mode":"all", "ha-sync-mode":"automatic"}'
+        fi
+      fi
+
+      if [[ -n $FEDERATE_WITH ]]; then
+        # FEDERATE_WITH can be a list of servers separated by ', '
+        IFS=', ' read -r -a fed_servers <<< "$FEDERATE_WITH"
+        for server in "${fed_servers[@]}"
+        do
+          if [[ -n $RABBITMQ_DEFAULT_USER ]] &&  [[ -n $RABBITMQ_DEFAULT_PASS ]]; then
+            rabbitmqctl set_parameter federation-upstream optimo-upstream '{"uri":"amqp://'$RABBITMQ_DEFAULT_USER':'$RABBITMQ_DEFAULT_PASS'@'$server'"}'
+          else
+            rabbitmqctl set_parameter federation-upstream optimo-upstream '{"uri":"amqp://'$server'"}'
+          fi
+        done
+
+        if [[ -n $RABBITMQ_POLICY_FEDERATION ]]; then
+          rabbitmqctl set_policy --apply-to queues optimo-fed-queues "^(?!amq\.).*" '{"federation-upstream-set":"all"}'
+        fi
+      fi
+      echo "RabbitMQ has successfully started."
+      break
+    else
+      echo "RabbitMQ is not running yet..."
+      sleep 5
+  fi
+done
+

--- a/3.8/ubuntu/Dockerfile
+++ b/3.8/ubuntu/Dockerfile
@@ -260,6 +260,9 @@ RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_prometheus; \
 	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 
+# add support for the federation
+RUN rabbitmq-plugins enable --offline rabbitmq_federation rabbitmq_federation_management
+
 # Added for backwards compatibility - users can simply COPY custom plugins to /plugins
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
@@ -275,6 +278,10 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
+
+ADD setup-server.sh /
+RUN chmod a+x /setup-server.sh
+/setup-server.sh &
 
 EXPOSE 4369 5671 5672 15691 15692 25672
 # Port range RabbitMQ will use for interprocess communication

--- a/3.8/ubuntu/Dockerfile
+++ b/3.8/ubuntu/Dockerfile
@@ -8,6 +8,9 @@
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:18.04
 
+ARG USER_ID
+ARG GROUP_ID
+
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -187,8 +190,8 @@ RUN set -eux; \
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 # Create rabbitmq system user & group, fix permissions & allow root user to connect to the RabbitMQ Erlang VM
 RUN set -eux; \
-	groupadd --gid 999 --system rabbitmq; \
-	useradd --uid 999 --system --home-dir "$RABBITMQ_DATA_DIR" --gid rabbitmq rabbitmq; \
+	groupadd --gid ${GROUP_ID:-999} --system rabbitmq; \
+	useradd --uid ${USER_ID:-999} --system --home-dir "$RABBITMQ_DATA_DIR" --gid rabbitmq rabbitmq; \
 	mkdir -p "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chown -fR rabbitmq:rabbitmq "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chmod 777 "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
@@ -274,4 +277,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 4369 5671 5672 15691 15692 25672
+# Port range RabbitMQ will use for interprocess communication
+EXPOSE 9100 9101 9102 9103 9104 9105
 CMD ["rabbitmq-server"]

--- a/3.8/ubuntu/management/Dockerfile
+++ b/3.8/ubuntu/management/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM rabbitmq:3.8
+FROM optimoroute/rabbitmq:3.8
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
 

--- a/3.8/ubuntu/management/Dockerfile
+++ b/3.8/ubuntu/management/Dockerfile
@@ -8,6 +8,9 @@ FROM optimoroute/rabbitmq:3.8
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
 
+# Add management agent to the image
+RUN rabbitmq-plugins enable --offline rabbitmq_management_agent
+
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 RUN rm -f /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 

--- a/3.8/ubuntu/setup-server.sh
+++ b/3.8/ubuntu/setup-server.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+while true
+do
+  rabbitmq-diagnostics check_running > /dev/null 2>&1
+  verifier=$?
+  if [[ $verifier == 0 ]]
+    then
+      if [[ -n $CLUSTER_WITH ]]; then
+          rabbitmqctl stop_app
+          if [[ -z $RAM_NODE ]]; then
+            rabbitmqctl join_cluster rabbit@"$CLUSTER_WITH"
+          else
+            rabbitmqctl join_cluster --ram rabbit@"$CLUSTER_WITH"
+          fi
+          rabbitmqctl start_app
+
+        if [[ -n $RABBITMQ_POLICY_HA_ALL ]]; then
+          rabbitmqctl set_policy ha-all "^(?!amq\.).*" '{"ha-mode":"all", "ha-sync-mode":"automatic"}'
+        fi
+      fi
+
+      if [[ -n $FEDERATE_WITH ]]; then
+        # FEDERATE_WITH can be a list of servers separated by ', '
+        IFS=', ' read -r -a fed_servers <<< "$FEDERATE_WITH"
+        for server in "${fed_servers[@]}"
+        do
+          if [[ -n $RABBITMQ_DEFAULT_USER ]] &&  [[ -n $RABBITMQ_DEFAULT_PASS ]]; then
+            rabbitmqctl set_parameter federation-upstream optimo-upstream '{"uri":"amqp://'$RABBITMQ_DEFAULT_USER':'$RABBITMQ_DEFAULT_PASS'@'$server'"}'
+          else
+            rabbitmqctl set_parameter federation-upstream optimo-upstream '{"uri":"amqp://'$server'"}'
+          fi
+        done
+
+        if [[ -n $RABBITMQ_POLICY_FEDERATION ]]; then
+          rabbitmqctl set_policy --apply-to queues optimo-fed-queues "^(?!amq\.).*" '{"federation-upstream-set":"all"}'
+        fi
+      fi
+      echo "RabbitMQ has successfully started."
+      break
+    else
+      echo "RabbitMQ is not running yet..."
+      sleep 5
+  fi
+done
+

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,6 +1,9 @@
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
 FROM alpine:3.13
 
+ARG USER_ID
+ARG GROUP_ID
+
 RUN apk add --no-cache \
 # grab su-exec for easy step-down from root
 		'su-exec>=0.2' \
@@ -192,8 +195,8 @@ RUN set -eux; \
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 # Create rabbitmq system user & group, fix permissions & allow root user to connect to the RabbitMQ Erlang VM
 RUN set -eux; \
-	addgroup -g 101 -S rabbitmq; \
-	adduser -u 100 -S -h "$RABBITMQ_DATA_DIR" -G rabbitmq rabbitmq; \
+	addgroup -g ${GROUP_ID:-101} -S rabbitmq; \
+	adduser -u ${USER_ID:-100} -S -h "$RABBITMQ_DATA_DIR" -G rabbitmq rabbitmq; \
 	mkdir -p "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chown -fR rabbitmq:rabbitmq "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chmod 777 "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \

--- a/Dockerfile-management.template
+++ b/Dockerfile-management.template
@@ -1,5 +1,5 @@
 FROM {{
-	"rabbitmq:" + env.version
+	"optimoroute/rabbitmq:" + env.version
 	+ if env.variant == "alpine" then "-alpine" else "" end
 }}
 

--- a/Dockerfile-management.template
+++ b/Dockerfile-management.template
@@ -5,6 +5,9 @@ FROM {{
 
 RUN rabbitmq-plugins enable --offline rabbitmq_management
 
+# Add management agent to the image
+RUN rabbitmq-plugins enable --offline rabbitmq_management_agent
+
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 RUN rm -f /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -276,6 +276,9 @@ RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_prometheus; \
 	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 
+# add support for the federation
+RUN rabbitmq-plugins enable --offline rabbitmq_federation rabbitmq_federation_management
+
 # Added for backwards compatibility - users can simply COPY custom plugins to /plugins
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
@@ -291,6 +294,10 @@ ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
+
+ADD setup-server.sh /
+RUN chmod a+x /setup-server.sh
+/setup-server.sh &
 
 EXPOSE 4369 5671 5672 15691 15692 25672
 # Port range RabbitMQ will use for interprocess communication

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -2,6 +2,9 @@
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:18.04
 
+ARG USER_ID
+ARG GROUP_ID
+
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -203,8 +206,8 @@ RUN set -eux; \
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 # Create rabbitmq system user & group, fix permissions & allow root user to connect to the RabbitMQ Erlang VM
 RUN set -eux; \
-	groupadd --gid 999 --system rabbitmq; \
-	useradd --uid 999 --system --home-dir "$RABBITMQ_DATA_DIR" --gid rabbitmq rabbitmq; \
+	groupadd --gid ${GROUP_ID:-999} --system rabbitmq; \
+	useradd --uid ${USER_ID:-999} --system --home-dir "$RABBITMQ_DATA_DIR" --gid rabbitmq rabbitmq; \
 	mkdir -p "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chown -fR rabbitmq:rabbitmq "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
 	chmod 777 "$RABBITMQ_DATA_DIR" /etc/rabbitmq /etc/rabbitmq/conf.d /tmp/rabbitmq-ssl /var/log/rabbitmq; \
@@ -290,4 +293,6 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 4369 5671 5672 15691 15692 25672
+# Port range RabbitMQ will use for interprocess communication
+EXPOSE 9100 9101 9102 9103 9104 9105
 CMD ["rabbitmq-server"]


### PR DESCRIPTION
This is the new setup for RabbitMQ server. Previous setup used RabbitMQ image and then created a custom image based on that one. While this approach is perfectly valid, it doesn't solve the problem where rabbitMQ has user id and group id 999 which corresponds to `systemd-coredump` user.
There is no way to correct this behavior when stock RabbitMQ image is already used.

SOLUTION: forking rabbitmq docker repo, set changes to be able to give user id and group id via env variables so that container is run as an unprivileged user that has the same ID as the machine host user so we won't have permission issues. 

Also, in current form, RabbitMQ is built using modified `docker-entrypoint.sh` and custom script that sets federation via 10 sec wait and service restart. Proposition is to use stock `docker-entrypoint.sh` and script is modified to use new features for rabbitmq diagnostics to restart the image with the federation enabled and configured.