### PR TITLE
Fix ownership of `management_agent.disable_metrics_collector.conf` and `enabled_plugins` files

### DIFF
--- a/3.8-rc/alpine/Dockerfile
+++ b/3.8-rc/alpine/Dockerfile
@@ -236,8 +236,9 @@ RUN set -eux; \
 
 # Enable Prometheus-style metrics by default (https://github.com/docker-library/rabbitmq/issues/419)
 RUN set -eux; \
-	rabbitmq-plugins enable --offline rabbitmq_prometheus; \
-	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
+	su-exec rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus; \
+	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf; \
+	chown rabbitmq:rabbitmq /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 
 # Added for backwards compatibility - users can simply COPY custom plugins to /plugins
 RUN ln -sf /opt/rabbitmq/plugins /plugins

--- a/3.8-rc/ubuntu/Dockerfile
+++ b/3.8-rc/ubuntu/Dockerfile
@@ -254,8 +254,9 @@ RUN set -eux; \
 
 # Enable Prometheus-style metrics by default (https://github.com/docker-library/rabbitmq/issues/419)
 RUN set -eux; \
-	rabbitmq-plugins enable --offline rabbitmq_prometheus; \
-	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
+	gosu rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus; \
+	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf; \
+	chown rabbitmq:rabbitmq /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 
 # Added for backwards compatibility - users can simply COPY custom plugins to /plugins
 RUN ln -sf /opt/rabbitmq/plugins /plugins

--- a/3.8/alpine/Dockerfile
+++ b/3.8/alpine/Dockerfile
@@ -236,8 +236,9 @@ RUN set -eux; \
 
 # Enable Prometheus-style metrics by default (https://github.com/docker-library/rabbitmq/issues/419)
 RUN set -eux; \
-	rabbitmq-plugins enable --offline rabbitmq_prometheus; \
-	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
+	su-exec rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus; \
+	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf; \
+	chown rabbitmq:rabbitmq /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 
 # Added for backwards compatibility - users can simply COPY custom plugins to /plugins
 RUN ln -sf /opt/rabbitmq/plugins /plugins

--- a/3.8/ubuntu/Dockerfile
+++ b/3.8/ubuntu/Dockerfile
@@ -254,8 +254,9 @@ RUN set -eux; \
 
 # Enable Prometheus-style metrics by default (https://github.com/docker-library/rabbitmq/issues/419)
 RUN set -eux; \
-	rabbitmq-plugins enable --offline rabbitmq_prometheus; \
-	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
+	gosu rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus; \
+	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf; \
+	chown rabbitmq:rabbitmq /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 
 # Added for backwards compatibility - users can simply COPY custom plugins to /plugins
 RUN ln -sf /opt/rabbitmq/plugins /plugins

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -252,8 +252,9 @@ RUN set -eux; \
 
 # Enable Prometheus-style metrics by default (https://github.com/docker-library/rabbitmq/issues/419)
 RUN set -eux; \
-	rabbitmq-plugins enable --offline rabbitmq_prometheus; \
-	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
+	su-exec rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus; \
+	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf; \
+	chown rabbitmq:rabbitmq /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 
 # Added for backwards compatibility - users can simply COPY custom plugins to /plugins
 RUN ln -sf /opt/rabbitmq/plugins /plugins

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -270,8 +270,9 @@ RUN set -eux; \
 
 # Enable Prometheus-style metrics by default (https://github.com/docker-library/rabbitmq/issues/419)
 RUN set -eux; \
-	rabbitmq-plugins enable --offline rabbitmq_prometheus; \
-	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
+	gosu rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus; \
+	echo 'management_agent.disable_metrics_collector = true' > /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf; \
+	chown rabbitmq:rabbitmq /etc/rabbitmq/conf.d/management_agent.disable_metrics_collector.conf
 
 # Added for backwards compatibility - users can simply COPY custom plugins to /plugins
 RUN ln -sf /opt/rabbitmq/plugins /plugins


### PR DESCRIPTION
Before:
```console
root@9857b56f8687:/# ls -la /etc/rabbitmq/*
-rw-r--r-- 1 root     root       23 Feb  4 22:58 /etc/rabbitmq/enabled_plugins

/etc/rabbitmq/conf.d:
total 12
drwxrwxrwx 1 rabbitmq rabbitmq 4096 Feb  4 22:58 .
drwxrwxrwx 1 rabbitmq rabbitmq 4096 Feb  4 22:58 ..
-rw-r--r-- 1 root     root       50 Feb  4 22:58 management_agent.disable_metrics_collector.conf
```

After:
```console
root@bd7a81ff36a5:/# ls -la /etc/rabbitmq/*
-rw-r--r-- 1 rabbitmq rabbitmq   23 Mar 17 21:37 /etc/rabbitmq/enabled_plugins

/etc/rabbitmq/conf.d:
total 12
drwxrwxrwx 1 rabbitmq rabbitmq 4096 Mar 17 21:37 .
drwxrwxrwx 1 rabbitmq rabbitmq 4096 Mar 17 21:37 ..
-rw-r--r-- 1 rabbitmq rabbitmq   50 Mar 17 21:37 management_agent.disable_metrics_collector.conf
```