### PR TITLE
Fix bug in detecting if management plugin is installed

### DIFF
--- a/3.8-rc/alpine/docker-entrypoint.sh
+++ b/3.8-rc/alpine/docker-entrypoint.sh
@@ -375,7 +375,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 
 	# if management plugin is installed, generate config for it
 	# https://www.rabbitmq.com/management.html#configuration
-	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
+	if [ "$(rabbitmq-plugins list -q -m -e '^rabbitmq_management$')" ]; then
 		if [ "$haveManagementSslConfig" ]; then
 			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"

--- a/3.8-rc/ubuntu/docker-entrypoint.sh
+++ b/3.8-rc/ubuntu/docker-entrypoint.sh
@@ -375,7 +375,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 
 	# if management plugin is installed, generate config for it
 	# https://www.rabbitmq.com/management.html#configuration
-	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
+	if [ "$(rabbitmq-plugins list -q -m -e '^rabbitmq_management$')" ]; then
 		if [ "$haveManagementSslConfig" ]; then
 			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"

--- a/3.8/alpine/docker-entrypoint.sh
+++ b/3.8/alpine/docker-entrypoint.sh
@@ -375,7 +375,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 
 	# if management plugin is installed, generate config for it
 	# https://www.rabbitmq.com/management.html#configuration
-	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
+	if [ "$(rabbitmq-plugins list -q -m -e '^rabbitmq_management$')" ]; then
 		if [ "$haveManagementSslConfig" ]; then
 			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"

--- a/3.8/ubuntu/docker-entrypoint.sh
+++ b/3.8/ubuntu/docker-entrypoint.sh
@@ -375,7 +375,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 
 	# if management plugin is installed, generate config for it
 	# https://www.rabbitmq.com/management.html#configuration
-	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
+	if [ "$(rabbitmq-plugins list -q -m -e '^rabbitmq_management$')" ]; then
 		if [ "$haveManagementSslConfig" ]; then
 			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -375,7 +375,7 @@ if [ "$1" = 'rabbitmq-server' ] && [ "$shouldWriteConfig" ]; then
 
 	# if management plugin is installed, generate config for it
 	# https://www.rabbitmq.com/management.html#configuration
-	if [ "$(rabbitmq-plugins list -q -m -e rabbitmq_management)" ]; then
+	if [ "$(rabbitmq-plugins list -q -m -e '^rabbitmq_management$')" ]; then
 		if [ "$haveManagementSslConfig" ]; then
 			rabbit_set_config 'management.ssl.port' 15671
 			rabbit_env_config 'management_ssl' "${sslConfigKeys[@]}"


### PR DESCRIPTION

```console
$ docker run -it --rm rabbitmq:3.8.16 rabbitmq-plugins list -q -m -e rabbitmq_management
rabbitmq_management_agent
$ docker run -it --rm rabbitmq:3.8.16-management rabbitmq-plugins list -q -m -e rabbitmq_management
rabbitmq_management
rabbitmq_management_agent
```
```console
$ docker run -it --rm rabbitmq:3.8.16 rabbitmq-plugins list -q -m -e '^rabbitmq_management$'
$ docker run -it --rm rabbitmq:3.8.16-management rabbitmq-plugins list -q -m -e '^rabbitmq_management$'
rabbitmq_management
```