### PR TITLE
Enable JIT, install g++

### DIFF
--- a/3.8-rc/alpine/Dockerfile
+++ b/3.8-rc/alpine/Dockerfile
@@ -43,6 +43,7 @@ RUN set -eux; \
 		autoconf \
 		dpkg-dev dpkg \
 		gcc \
+		g++ \
 		gnupg \
 		libc-dev \
 		linux-headers \
@@ -122,6 +123,7 @@ RUN set -eux; \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-jit
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \

--- a/3.8-rc/alpine/Dockerfile
+++ b/3.8-rc/alpine/Dockerfile
@@ -123,7 +123,7 @@ RUN set -eux; \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
-		--enable-jit
+		--enable-jit \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \

--- a/3.8-rc/ubuntu/Dockerfile
+++ b/3.8-rc/ubuntu/Dockerfile
@@ -49,6 +49,7 @@ RUN set -eux; \
 		ca-certificates \
 		dpkg-dev \
 		gcc \
+		g++ \
 		gnupg \
 		libncurses5-dev \
 		make \
@@ -129,6 +130,7 @@ RUN set -eux; \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-jit \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \

--- a/3.8/alpine/Dockerfile
+++ b/3.8/alpine/Dockerfile
@@ -43,6 +43,7 @@ RUN set -eux; \
 		autoconf \
 		dpkg-dev dpkg \
 		gcc \
+		g++ \
 		gnupg \
 		libc-dev \
 		linux-headers \
@@ -122,6 +123,7 @@ RUN set -eux; \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-jit
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \

--- a/3.8/alpine/Dockerfile
+++ b/3.8/alpine/Dockerfile
@@ -123,7 +123,7 @@ RUN set -eux; \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
-		--enable-jit
+		--enable-jit \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \

--- a/3.8/ubuntu/Dockerfile
+++ b/3.8/ubuntu/Dockerfile
@@ -49,6 +49,7 @@ RUN set -eux; \
 		ca-certificates \
 		dpkg-dev \
 		gcc \
+		g++ \
 		gnupg \
 		libncurses5-dev \
 		make \
@@ -129,6 +130,7 @@ RUN set -eux; \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-jit \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -59,6 +59,7 @@ RUN set -eux; \
 		autoconf \
 		dpkg-dev dpkg \
 		gcc \
+		g++ \
 		gnupg \
 		libc-dev \
 		linux-headers \
@@ -138,6 +139,7 @@ RUN set -eux; \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-jit
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -139,7 +139,7 @@ RUN set -eux; \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
-		--enable-jit
+		--enable-jit \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -65,6 +65,7 @@ RUN set -eux; \
 		ca-certificates \
 		dpkg-dev \
 		gcc \
+		g++ \
 		gnupg \
 		libncurses5-dev \
 		make \
@@ -145,6 +146,7 @@ RUN set -eux; \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-jit \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \


### PR DESCRIPTION
Erlang 24 provides JIT support that requires c++17-compatible compiler.
Without the `g++` package, `autoconf` considers this support missing and
therefore silently disables JIT. This commit makes sure that:
1. g++ is installed (this makes `autoconf` detect it correctly as
   c++17-compatible)
2. Explicitly enables JIT so that it fails in case something changes in
   the future. JIT is a great feature so we don't want it being silently
   turned off for any reason.