### PR TITLE
Use conf.d to enable console logging in RMQ 3.9+

### DIFF
--- a/10-defaults.conf
+++ b/10-defaults.conf
@@ -6,3 +6,7 @@
 ## https://www.rabbitmq.com/access-control.html#loopback-users
 ## https://www.rabbitmq.com/production-checklist.html#users
 loopback_users.guest = false
+
+## Send all logs to stdout/TTY. Necessary to see logs when running via
+## a container
+log.console = true

--- a/3.10-rc/alpine/10-defaults.conf
+++ b/3.10-rc/alpine/10-defaults.conf
@@ -6,3 +6,7 @@
 ## https://www.rabbitmq.com/access-control.html#loopback-users
 ## https://www.rabbitmq.com/production-checklist.html#users
 loopback_users.guest = false
+
+## Send all logs to stdout/TTY. Necessary to see logs when running via
+## a container
+log.console = true

--- a/3.10-rc/alpine/Dockerfile
+++ b/3.10-rc/alpine/Dockerfile
@@ -195,9 +195,8 @@ ENV RABBITMQ_VERSION 3.10.0-beta.4
 ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
-# Add RabbitMQ to PATH, send all logs to TTY
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=-
+# Add RabbitMQ to PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -259,7 +258,7 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
-COPY --chown=rabbitmq:rabbitmq 10-default-guest-user.conf /etc/rabbitmq/conf.d/
+COPY --chown=rabbitmq:rabbitmq 10-defaults.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/3.10-rc/ubuntu/10-defaults.conf
+++ b/3.10-rc/ubuntu/10-defaults.conf
@@ -6,3 +6,7 @@
 ## https://www.rabbitmq.com/access-control.html#loopback-users
 ## https://www.rabbitmq.com/production-checklist.html#users
 loopback_users.guest = false
+
+## Send all logs to stdout/TTY. Necessary to see logs when running via
+## a container
+log.console = true

--- a/3.10-rc/ubuntu/Dockerfile
+++ b/3.10-rc/ubuntu/Dockerfile
@@ -206,9 +206,8 @@ ENV RABBITMQ_VERSION 3.10.0-beta.4
 ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
-# Add RabbitMQ to PATH, send all logs to TTY
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=-
+# Add RabbitMQ to PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -277,7 +276,7 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
-COPY --chown=rabbitmq:rabbitmq 10-default-guest-user.conf /etc/rabbitmq/conf.d/
+COPY --chown=rabbitmq:rabbitmq 10-defaults.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/3.9/alpine/10-defaults.conf
+++ b/3.9/alpine/10-defaults.conf
@@ -6,3 +6,7 @@
 ## https://www.rabbitmq.com/access-control.html#loopback-users
 ## https://www.rabbitmq.com/production-checklist.html#users
 loopback_users.guest = false
+
+## Send all logs to stdout/TTY. Necessary to see logs when running via
+## a container
+log.console = true

--- a/3.9/alpine/Dockerfile
+++ b/3.9/alpine/Dockerfile
@@ -195,9 +195,8 @@ ENV RABBITMQ_VERSION 3.9.13
 ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
-# Add RabbitMQ to PATH, send all logs to TTY
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=-
+# Add RabbitMQ to PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -259,7 +258,7 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
-COPY --chown=rabbitmq:rabbitmq 10-default-guest-user.conf /etc/rabbitmq/conf.d/
+COPY --chown=rabbitmq:rabbitmq 10-defaults.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/3.9/ubuntu/10-defaults.conf
+++ b/3.9/ubuntu/10-defaults.conf
@@ -6,3 +6,7 @@
 ## https://www.rabbitmq.com/access-control.html#loopback-users
 ## https://www.rabbitmq.com/production-checklist.html#users
 loopback_users.guest = false
+
+## Send all logs to stdout/TTY. Necessary to see logs when running via
+## a container
+log.console = true

--- a/3.9/ubuntu/Dockerfile
+++ b/3.9/ubuntu/Dockerfile
@@ -206,9 +206,8 @@ ENV RABBITMQ_VERSION 3.9.13
 ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
-# Add RabbitMQ to PATH, send all logs to TTY
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
-	RABBITMQ_LOGS=-
+# Add RabbitMQ to PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -277,7 +276,7 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
-COPY --chown=rabbitmq:rabbitmq 10-default-guest-user.conf /etc/rabbitmq/conf.d/
+COPY --chown=rabbitmq:rabbitmq 10-defaults.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -211,9 +211,15 @@ ENV RABBITMQ_VERSION {{ .version }}
 ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
+{{ if ([ "3.8", "3.8-rc" ] | index(env.version)) then ( -}}
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
 	RABBITMQ_LOGS=-
+{{ )
+else ( -}}
+# Add RabbitMQ to PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+{{ ) end -}}
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -276,7 +282,7 @@ VOLUME $RABBITMQ_DATA_DIR
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
 {{ if ([ "3.8", "3.8-rc" ] | index(env.version)) then "" else ( -}}
-COPY --chown=rabbitmq:rabbitmq 10-default-guest-user.conf /etc/rabbitmq/conf.d/
+COPY --chown=rabbitmq:rabbitmq 10-defaults.conf /etc/rabbitmq/conf.d/
 {{ ) end -}}
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -222,9 +222,15 @@ ENV RABBITMQ_VERSION {{ .version }}
 ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
+{{ if ([ "3.8", "3.8-rc" ] | index(env.version)) then ( -}}
 # Add RabbitMQ to PATH, send all logs to TTY
 ENV PATH=$RABBITMQ_HOME/sbin:$PATH \
 	RABBITMQ_LOGS=-
+{{ )
+else ( -}}
+# Add RabbitMQ to PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+{{ ) end -}}
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -294,7 +300,7 @@ VOLUME $RABBITMQ_DATA_DIR
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
 {{ if ([ "3.8", "3.8-rc" ] | index(env.version)) then "" else ( -}}
-COPY --chown=rabbitmq:rabbitmq 10-default-guest-user.conf /etc/rabbitmq/conf.d/
+COPY --chown=rabbitmq:rabbitmq 10-defaults.conf /etc/rabbitmq/conf.d/
 {{ ) end -}}
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -55,7 +55,7 @@ for version; do
 		cp -a "$entrypoint" "$version/$variant/docker-entrypoint.sh"
 
 		if [ "$rcVersion" != '3.8' ]; then
-			cp 10-default-guest-user.conf "$version/$variant/"
+			cp 10-defaults.conf "$version/$variant/"
 		fi
 
 		if [ "$variant" = 'alpine' ]; then


### PR DESCRIPTION
This replaces the `RABBITMQ_LOGS=-` env variable.

Fixes #554

Test procedure is documented here:

https://github.com/lukebakken/test-docker-library-rabbitmq-gh-554