### PR TITLE
Bring in tzdata so users could set the timezones through the environment

### DIFF
--- a/3.10/alpine/Dockerfile
+++ b/3.10/alpine/Dockerfile
@@ -13,7 +13,9 @@ RUN apk add --no-cache \
 # bash for docker-entrypoint.sh
 		bash \
 # "ps" for "rabbitmqctl wait" (https://github.com/docker-library/rabbitmq/issues/162)
-		procps
+		procps \
+# Bring in tzdata so users could set the timezones through the environment
+		tzdata
 
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com

--- a/3.10/ubuntu/Dockerfile
+++ b/3.10/ubuntu/Dockerfile
@@ -13,6 +13,8 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 # grab gosu for easy step-down from root
 		gosu \
+# Bring in tzdata so users could set the timezones through the environment
+		tzdata \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # verify that the "gosu" binary works

--- a/3.9/alpine/Dockerfile
+++ b/3.9/alpine/Dockerfile
@@ -13,7 +13,9 @@ RUN apk add --no-cache \
 # bash for docker-entrypoint.sh
 		bash \
 # "ps" for "rabbitmqctl wait" (https://github.com/docker-library/rabbitmq/issues/162)
-		procps
+		procps \
+# Bring in tzdata so users could set the timezones through the environment
+		tzdata
 
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com

--- a/3.9/ubuntu/Dockerfile
+++ b/3.9/ubuntu/Dockerfile
@@ -13,6 +13,8 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 # grab gosu for easy step-down from root
 		gosu \
+# Bring in tzdata so users could set the timezones through the environment
+		tzdata \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # verify that the "gosu" binary works

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -7,7 +7,9 @@ RUN apk add --no-cache \
 # bash for docker-entrypoint.sh
 		bash \
 # "ps" for "rabbitmqctl wait" (https://github.com/docker-library/rabbitmq/issues/162)
-		procps
+		procps \
+# Bring in tzdata so users could set the timezones through the environment
+		tzdata
 
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -7,6 +7,8 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 # grab gosu for easy step-down from root
 		gosu \
+# Bring in tzdata so users could set the timezones through the environment
+		tzdata \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 # verify that the "gosu" binary works


### PR DESCRIPTION
Supports using the `TZ` environment variable to set the timezone instead of using the volume bindings: `/etc/timezone:/etc/timezone` and `/etc/localtime:/etc/localtime`.

This is really great if you can support it.:heart: