### PR TITLE
Fix URL scraping thanks to GitHub changes

### DIFF
--- a/versions.sh
+++ b/versions.sh
@@ -53,8 +53,11 @@ for version in "${versions[@]}"; do
 	githubTag=
 	for possibleTag in "${githubTags[@]}"; do
 		fullVersion="$(
-			wget -qO- "https://github.com/rabbitmq/rabbitmq-server/releases/tag/$possibleTag" \
-				| grep -oE "/rabbitmq-server-generic-unix-${rcVersion}([.-].+)?[.]tar[.]xz" \
+			{
+				# thanks GitHub...
+				wget -qO- "https://github.com/rabbitmq/rabbitmq-server/releases/expanded_assets/$possibleTag" \
+				|| wget -qO- "https://github.com/rabbitmq/rabbitmq-server/releases/tag/$possibleTag"
+			} | grep -oE "/rabbitmq-server-generic-unix-${rcVersion}([.-].+)?[.]tar[.]xz" \
 				| head -1 \
 				| sed -r "s/^.*(${rcVersion}.*)[.]tar[.]xz/\1/" \
 				|| :


### PR DESCRIPTION
Pages like https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.11.0 no longer contain the links directly:

```html
          <details open="open" data-view-component="true">
  <summary role="button" data-view-component="true">    <span data-view-component="true" class="f3 text-bold d-inline mr-3">Assets</span>
    <span title="32" data-view-component="true" class="Counter ml-1">32</span>
</summary>
  <div data-view-component="true">        <include-fragment loading="lazy" src="https://github.com/rabbitmq/rabbitmq-server/releases/expanded_assets/v3.11.0" data-test-selector="lazy-asset-list-fragment">
          <svg style="box-sizing: content-box; color: var(--color-icon-primary);" width="32" height="32" viewBox="0 0 16 16" fill="none" data-view-component="true" class="anim-rotate">
  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
</svg>
        </include-fragment>
</div>
</details>
```