### PR TITLE
Update to 3.9.23

### DIFF
--- a/3.9/alpine/Dockerfile
+++ b/3.9/alpine/Dockerfile
@@ -28,10 +28,10 @@ ENV OPENSSL_SOURCE_SHA256="d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51
 # https://www.openssl.org/community/omc.html
 ENV OPENSSL_PGP_KEY_IDS="0x8657ABB260F056B1E5190839D9C4D26D0E604491 0x5B2545DAB21995F4088CEFAA36CEE4DEB00CFE33 0xED230BEC4D4F2518B9D7DF41F0DB4D21C1D35231 0xC1F33DD8CE1D4CC613AF14DA9195C48241FBF7DD 0x7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C 0xE5E52560DD91C556DDBDA5D02064C53641C25E5D"
 
-ENV OTP_VERSION 24.3.4.5
+ENV OTP_VERSION 25.1.1
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
-ENV OTP_SOURCE_SHA256="0b57d49e62958350676e8f32a39008d420dca4bc20f2d7e38c0671ab2ba62f14"
+ENV OTP_SOURCE_SHA256="42840c32e13a27bdb2c376d69aa22466513d441bfe5eb882de23baf8218308d3"
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -192,7 +192,7 @@ RUN set -eux; \
 	ln -sf "$RABBITMQ_DATA_DIR/.erlang.cookie" /root/.erlang.cookie
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION 3.9.22
+ENV RABBITMQ_VERSION 3.9.23
 # https://www.rabbitmq.com/signatures.html#importing-gpg
 ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq

--- a/3.9/ubuntu/Dockerfile
+++ b/3.9/ubuntu/Dockerfile
@@ -31,10 +31,10 @@ ENV OPENSSL_SOURCE_SHA256="d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51
 # https://www.openssl.org/community/omc.html
 ENV OPENSSL_PGP_KEY_IDS="0x8657ABB260F056B1E5190839D9C4D26D0E604491 0x5B2545DAB21995F4088CEFAA36CEE4DEB00CFE33 0xED230BEC4D4F2518B9D7DF41F0DB4D21C1D35231 0xC1F33DD8CE1D4CC613AF14DA9195C48241FBF7DD 0x7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C 0xE5E52560DD91C556DDBDA5D02064C53641C25E5D"
 
-ENV OTP_VERSION 24.3.4.5
+ENV OTP_VERSION 25.1.1
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
-ENV OTP_SOURCE_SHA256="0b57d49e62958350676e8f32a39008d420dca4bc20f2d7e38c0671ab2ba62f14"
+ENV OTP_SOURCE_SHA256="42840c32e13a27bdb2c376d69aa22466513d441bfe5eb882de23baf8218308d3"
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -203,7 +203,7 @@ RUN set -eux; \
 	ln -sf "$RABBITMQ_DATA_DIR/.erlang.cookie" /root/.erlang.cookie
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION 3.9.22
+ENV RABBITMQ_VERSION 3.9.23
 # https://www.rabbitmq.com/signatures.html#importing-gpg
 ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq

--- a/versions.json
+++ b/versions.json
@@ -29,10 +29,10 @@
       "version": "1.1.1q"
     },
     "otp": {
-      "sha256": "0b57d49e62958350676e8f32a39008d420dca4bc20f2d7e38c0671ab2ba62f14",
-      "version": "24.3.4.5"
+      "sha256": "42840c32e13a27bdb2c376d69aa22466513d441bfe5eb882de23baf8218308d3",
+      "version": "25.1.1"
     },
-    "version": "3.9.22"
+    "version": "3.9.23"
   },
   "3.9-rc": null
 }

--- a/versions.sh
+++ b/versions.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 # https://www.rabbitmq.com/which-erlang.html ("Maximum supported Erlang/OTP")
 declare -A otpMajors=(
-	[3.9]='24'
+	[3.9]='25'
 	[3.10]='25'
 	[3.11]='25'
 )


### PR DESCRIPTION
We're getting the following on the automated updates: (which I expect CI on this PR is going to hit as well)

```console
+ gosu rabbitmq rabbitmqctl help
=ERROR REPORT==== 26-Sep-2022::17:22:12.758883 ===
beam/beam_load.c(162): Error loading module elixir:
  This BEAM file was compiled for a later version of the run-time system than 24.
  To fix this, please recompile this module with an 24 compiler.
  (Use of opcode 178; this emulator supports only up to 176.)


=ERROR REPORT==== 26-Sep-2022::17:22:12.758901 ===
Loading of /opt/rabbitmq/escript/rabbitmqctl/elixir.beam failed: badfile

=CRASH REPORT==== 26-Sep-2022::17:22:12.758983 ===
  crasher:
    initial call: application_master:init/4
    pid: <0.80.0>
    registered_name: []
    exception exit: {bad_return,
                        {{elixir,start,[normal,[]]},
                         {'EXIT',
                             {undef,
                                 [{elixir,start,[normal,[]],[]},
                                  {application_master,start_it_old,4,
                                      [{file,"application_master.erl"},
                                       {line,293}]}]}}}}
      in function  application_master:init/4 (application_master.erl, line 142)
    ancestors: [<0.79.0>]
    message_queue_len: 1
    messages: [{'EXIT',<0.81.0>,normal}]
    links: [<0.79.0>,<0.44.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 987
    stack_size: 29
    reductions: 158
  neighbours:

=INFO REPORT==== 26-Sep-2022::17:22:12.798817 ===
    application: elixir
    exited: {bad_return,
                {{elixir,start,[normal,[]]},
                 {'EXIT',
                     {undef,
                         [{elixir,start,[normal,[]],[]},
                          {application_master,start_it_old,4,
                              [{file,"application_master.erl"},
                               {line,293}]}]}}}}
    type: temporary

=INFO REPORT==== 26-Sep-2022::17:22:12.799004 ===
    application: compiler
    exited: stopped
    type: temporary

ERROR! Failed to start Elixir.
error: {error,
           {elixir,
               {bad_return,
                   {{elixir,start,[normal,[]]},
                    {'EXIT',
                        {undef,
                            [{elixir,start,[normal,[]],[]},
                             {application_master,start_it_old,4,
                                 [{file,"application_master.erl"},
                                  {line,293}]}]}}}}}}
```

I checked https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.9.23, and it looks like Erlang 24 _is_ still supposed to be supported on this release (so partly a glitch in the upstream builds, perhaps?) but it's probably also safe for us to upgrade to Erlang 25 on RabbitMQ 3.9 now?