### PR TITLE
Explicitly enable builtin zlib

### DIFF
--- a/3.10/alpine/Dockerfile
+++ b/3.10/alpine/Dockerfile
@@ -125,7 +125,7 @@ RUN set -eux; \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-shared-zlib \
+		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \

--- a/3.10/ubuntu/Dockerfile
+++ b/3.10/ubuntu/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-shared-zlib \
+		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \

--- a/3.11/alpine/Dockerfile
+++ b/3.11/alpine/Dockerfile
@@ -125,7 +125,7 @@ RUN set -eux; \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-shared-zlib \
+		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \

--- a/3.11/ubuntu/Dockerfile
+++ b/3.11/ubuntu/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-shared-zlib \
+		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \

--- a/3.12-rc/alpine/Dockerfile
+++ b/3.12-rc/alpine/Dockerfile
@@ -125,7 +125,7 @@ RUN set -eux; \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-shared-zlib \
+		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \

--- a/3.12-rc/ubuntu/Dockerfile
+++ b/3.12-rc/ubuntu/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-shared-zlib \
+		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \

--- a/3.9/alpine/Dockerfile
+++ b/3.9/alpine/Dockerfile
@@ -125,7 +125,7 @@ RUN set -eux; \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-shared-zlib \
+		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \

--- a/3.9/ubuntu/Dockerfile
+++ b/3.9/ubuntu/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-shared-zlib \
+		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -155,7 +155,7 @@ RUN set -eux; \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-shared-zlib \
+		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -154,7 +154,7 @@ RUN set -eux; \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-shared-zlib \
+		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \


### PR DESCRIPTION
Until now, the `./configure` option attempted to use shared (system-provided) zlib. However, the image, at least ubuntu doesn't have `zlib1g-dev` package installed, so OTP falls back to using builtin zlib. Therefore, this commit shouldn't change the contents of the image that gets built, but makes it explicit that it uses zlib version included in OTP (currently 1.2.12).

The alternative would be to install the missing package and actually use ubuntu-provided zlib version. However, that would be a change in behaviour and a negative one - there was a significant performance improvement included in 1.2.12, that we would have lost.