### PR TITLE
Add Erlang JIT on arm64

### DIFF
--- a/3.10/alpine/Dockerfile
+++ b/3.10/alpine/Dockerfile
@@ -110,10 +110,10 @@ RUN set -eux; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
-# JIT is only supported on amd64 (until 24.x+1, where it will support arm64 as well); https://github.com/erlang/otp/blob/OTP-24.0.5/erts/configure#L21694-L21709 / https://github.com/erlang/otp/pull/4869
+# JIT is only supported on amd64 + arm64; https://github.com/erlang/otp/blob/OTP-25.3.2.2/erts/configure#L24306-L24347
 	jitFlag=; \
 	case "$dpkgArch" in \
-		amd64) jitFlag='--enable-jit' ;; \
+		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
 		--host="$hostArch" \

--- a/3.10/ubuntu/Dockerfile
+++ b/3.10/ubuntu/Dockerfile
@@ -109,10 +109,10 @@ RUN set -eux; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
-# JIT is only supported on amd64 (until 24.x+1, where it will support arm64 as well); https://github.com/erlang/otp/blob/OTP-24.0.5/erts/configure#L21694-L21709 / https://github.com/erlang/otp/pull/4869
+# JIT is only supported on amd64 + arm64; https://github.com/erlang/otp/blob/OTP-25.3.2.2/erts/configure#L24306-L24347
 	jitFlag=; \
 	case "$dpkgArch" in \
-		amd64) jitFlag='--enable-jit' ;; \
+		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
 		--host="$hostArch" \

--- a/3.11/alpine/Dockerfile
+++ b/3.11/alpine/Dockerfile
@@ -110,10 +110,10 @@ RUN set -eux; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
-# JIT is only supported on amd64 (until 24.x+1, where it will support arm64 as well); https://github.com/erlang/otp/blob/OTP-24.0.5/erts/configure#L21694-L21709 / https://github.com/erlang/otp/pull/4869
+# JIT is only supported on amd64 + arm64; https://github.com/erlang/otp/blob/OTP-25.3.2.2/erts/configure#L24306-L24347
 	jitFlag=; \
 	case "$dpkgArch" in \
-		amd64) jitFlag='--enable-jit' ;; \
+		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
 		--host="$hostArch" \

--- a/3.11/ubuntu/Dockerfile
+++ b/3.11/ubuntu/Dockerfile
@@ -109,10 +109,10 @@ RUN set -eux; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
-# JIT is only supported on amd64 (until 24.x+1, where it will support arm64 as well); https://github.com/erlang/otp/blob/OTP-24.0.5/erts/configure#L21694-L21709 / https://github.com/erlang/otp/pull/4869
+# JIT is only supported on amd64 + arm64; https://github.com/erlang/otp/blob/OTP-25.3.2.2/erts/configure#L24306-L24347
 	jitFlag=; \
 	case "$dpkgArch" in \
-		amd64) jitFlag='--enable-jit' ;; \
+		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
 		--host="$hostArch" \

--- a/3.12/alpine/Dockerfile
+++ b/3.12/alpine/Dockerfile
@@ -110,10 +110,10 @@ RUN set -eux; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
-# JIT is only supported on amd64 (until 24.x+1, where it will support arm64 as well); https://github.com/erlang/otp/blob/OTP-24.0.5/erts/configure#L21694-L21709 / https://github.com/erlang/otp/pull/4869
+# JIT is only supported on amd64 + arm64; https://github.com/erlang/otp/blob/OTP-25.3.2.2/erts/configure#L24306-L24347
 	jitFlag=; \
 	case "$dpkgArch" in \
-		amd64) jitFlag='--enable-jit' ;; \
+		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
 		--host="$hostArch" \

--- a/3.12/ubuntu/Dockerfile
+++ b/3.12/ubuntu/Dockerfile
@@ -109,10 +109,10 @@ RUN set -eux; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
-# JIT is only supported on amd64 (until 24.x+1, where it will support arm64 as well); https://github.com/erlang/otp/blob/OTP-24.0.5/erts/configure#L21694-L21709 / https://github.com/erlang/otp/pull/4869
+# JIT is only supported on amd64 + arm64; https://github.com/erlang/otp/blob/OTP-25.3.2.2/erts/configure#L24306-L24347
 	jitFlag=; \
 	case "$dpkgArch" in \
-		amd64) jitFlag='--enable-jit' ;; \
+		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
 		--host="$hostArch" \

--- a/3.9/alpine/Dockerfile
+++ b/3.9/alpine/Dockerfile
@@ -110,10 +110,10 @@ RUN set -eux; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
-# JIT is only supported on amd64 (until 24.x+1, where it will support arm64 as well); https://github.com/erlang/otp/blob/OTP-24.0.5/erts/configure#L21694-L21709 / https://github.com/erlang/otp/pull/4869
+# JIT is only supported on amd64 + arm64; https://github.com/erlang/otp/blob/OTP-25.3.2.2/erts/configure#L24306-L24347
 	jitFlag=; \
 	case "$dpkgArch" in \
-		amd64) jitFlag='--enable-jit' ;; \
+		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
 		--host="$hostArch" \

--- a/3.9/ubuntu/Dockerfile
+++ b/3.9/ubuntu/Dockerfile
@@ -109,10 +109,10 @@ RUN set -eux; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
-# JIT is only supported on amd64 (until 24.x+1, where it will support arm64 as well); https://github.com/erlang/otp/blob/OTP-24.0.5/erts/configure#L21694-L21709 / https://github.com/erlang/otp/pull/4869
+# JIT is only supported on amd64 + arm64; https://github.com/erlang/otp/blob/OTP-25.3.2.2/erts/configure#L24306-L24347
 	jitFlag=; \
 	case "$dpkgArch" in \
-		amd64) jitFlag='--enable-jit' ;; \
+		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
 		--host="$hostArch" \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -140,10 +140,10 @@ RUN set -eux; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
-# JIT is only supported on amd64 (until 24.x+1, where it will support arm64 as well); https://github.com/erlang/otp/blob/OTP-24.0.5/erts/configure#L21694-L21709 / https://github.com/erlang/otp/pull/4869
+# JIT is only supported on amd64 + arm64; https://github.com/erlang/otp/blob/OTP-25.3.2.2/erts/configure#L24306-L24347
 	jitFlag=; \
 	case "$dpkgArch" in \
-		amd64) jitFlag='--enable-jit' ;; \
+		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
 		--host="$hostArch" \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -139,10 +139,10 @@ RUN set -eux; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
-# JIT is only supported on amd64 (until 24.x+1, where it will support arm64 as well); https://github.com/erlang/otp/blob/OTP-24.0.5/erts/configure#L21694-L21709 / https://github.com/erlang/otp/pull/4869
+# JIT is only supported on amd64 + arm64; https://github.com/erlang/otp/blob/OTP-25.3.2.2/erts/configure#L24306-L24347
 	jitFlag=; \
 	case "$dpkgArch" in \
-		amd64) jitFlag='--enable-jit' ;; \
+		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
 		--host="$hostArch" \


### PR DESCRIPTION
This has been supported since 25.x, which we're using on all versions now. 👍

Closes #647