### PR TITLE
Fix builds on `arm32v6` and `arm32v7`

### DIFF
--- a/3.10/alpine/Dockerfile
+++ b/3.10/alpine/Dockerfile
@@ -36,8 +36,8 @@ ENV OTP_VERSION 25.3.2.5
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -50,7 +50,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -92,11 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -107,7 +107,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -131,7 +131,7 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -141,7 +141,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -154,7 +154,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -180,40 +180,45 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.18
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%n#p' --recursive $ERLANG_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX \
 			| tr ',' '\n' \
 			| sort -u \
+			| grep -v '^$\|lib\(crypto\|ssl\)' \
 			| awk 'system("test -e /usr/local/lib/" $1) == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
 # Check that OpenSSL still works after copying from previous builder
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -241,11 +246,11 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION 3.10.25
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.10/alpine/Dockerfile
+++ b/3.10/alpine/Dockerfile
@@ -35,6 +35,10 @@ ENV OTP_VERSION 25.3.2.5
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -46,7 +50,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -71,8 +75,9 @@ RUN set -eux; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		aarch64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6' ;; \
-		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6+fp' ;; \
+		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		ppc64le) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
 		s390x) opensslMachine='linux64-s390x' ;; \
@@ -87,10 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir=/usr/local/lib \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath=/usr/local/lib \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -124,8 +130,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -135,19 +141,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -173,24 +180,25 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.18
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
@@ -201,10 +209,10 @@ RUN set -eux; \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
-# Check that OpenSSL still works after purging build dependencies
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+# Check that OpenSSL still works after copying from previous builder
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.10/alpine/Dockerfile
+++ b/3.10/alpine/Dockerfile
@@ -213,6 +213,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.10/ubuntu/Dockerfile
+++ b/3.10/ubuntu/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -189,7 +189,7 @@ RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [cry
 
 FROM ubuntu:22.04
 
-# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
 ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
 ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
@@ -225,8 +225,8 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION 3.10.25
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
 ENV PATH $RABBITMQ_HOME/sbin:$PATH

--- a/3.10/ubuntu/Dockerfile
+++ b/3.10/ubuntu/Dockerfile
@@ -37,8 +37,8 @@ ENV OTP_VERSION 25.3.2.5
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -48,7 +48,7 @@ ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -91,11 +91,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -127,8 +127,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$OPENSSL_INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -138,7 +138,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -151,7 +151,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -178,32 +178,36 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:22.04
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -225,7 +229,7 @@ ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.10/ubuntu/Dockerfile
+++ b/3.10/ubuntu/Dockerfile
@@ -67,7 +67,6 @@ RUN set -eux; \
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
 # without specifying "--libdir", Erlang will fail during "crypto:supports()" looking for a "pthread_atfork" function that doesn't exist (but only on arm32v7/armhf??)
-	debMultiarch="$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 # OpenSSL's "config" script uses a lot of "uname"-based target detection...
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
 # https://deb.debian.org/debian/dists/unstable/main/
@@ -94,9 +93,9 @@ RUN set -eux; \
 		enable-fips \
 		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -128,8 +127,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -204,6 +203,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.10/ubuntu/Dockerfile
+++ b/3.10/ubuntu/Dockerfile
@@ -36,6 +36,10 @@ ENV OTP_VERSION 25.3.2.5
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -44,7 +48,7 @@ ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -69,11 +73,12 @@ RUN set -eux; \
 # https://deb.debian.org/debian/dists/unstable/main/
 	case "$dpkgArch" in \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
-# https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		amd64) opensslMachine='linux-x86_64' ;; \
 		arm64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://wiki.debian.org/ArchitectureSpecificsMemo#Architecture_baselines
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		i386) opensslMachine='linux-x86' ;; \
 		ppc64el) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
@@ -87,10 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="/usr/local/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="/usr/local/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -122,8 +128,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -133,19 +139,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -172,30 +179,31 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:22.04
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.11/alpine/Dockerfile
+++ b/3.11/alpine/Dockerfile
@@ -36,8 +36,8 @@ ENV OTP_VERSION 25.3.2.5
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -50,7 +50,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -92,11 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -107,7 +107,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -131,7 +131,7 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -141,7 +141,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -154,7 +154,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -180,40 +180,45 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.18
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%n#p' --recursive $ERLANG_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX \
 			| tr ',' '\n' \
 			| sort -u \
+			| grep -v '^$\|lib\(crypto\|ssl\)' \
 			| awk 'system("test -e /usr/local/lib/" $1) == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
 # Check that OpenSSL still works after copying from previous builder
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -241,11 +246,11 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION 3.11.21
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.11/alpine/Dockerfile
+++ b/3.11/alpine/Dockerfile
@@ -35,6 +35,10 @@ ENV OTP_VERSION 25.3.2.5
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -46,7 +50,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -71,8 +75,9 @@ RUN set -eux; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		aarch64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6' ;; \
-		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6+fp' ;; \
+		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		ppc64le) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
 		s390x) opensslMachine='linux64-s390x' ;; \
@@ -87,10 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir=/usr/local/lib \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath=/usr/local/lib \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -124,8 +130,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -135,19 +141,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -173,24 +180,25 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.18
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
@@ -201,10 +209,10 @@ RUN set -eux; \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
-# Check that OpenSSL still works after purging build dependencies
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+# Check that OpenSSL still works after copying from previous builder
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.11/alpine/Dockerfile
+++ b/3.11/alpine/Dockerfile
@@ -213,6 +213,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.11/ubuntu/Dockerfile
+++ b/3.11/ubuntu/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -189,7 +189,7 @@ RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [cry
 
 FROM ubuntu:22.04
 
-# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
 ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
 ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
@@ -225,8 +225,8 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION 3.11.21
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
 ENV PATH $RABBITMQ_HOME/sbin:$PATH

--- a/3.11/ubuntu/Dockerfile
+++ b/3.11/ubuntu/Dockerfile
@@ -37,8 +37,8 @@ ENV OTP_VERSION 25.3.2.5
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -48,7 +48,7 @@ ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -91,11 +91,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -127,8 +127,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$OPENSSL_INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -138,7 +138,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -151,7 +151,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -178,32 +178,36 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:22.04
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -225,7 +229,7 @@ ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.11/ubuntu/Dockerfile
+++ b/3.11/ubuntu/Dockerfile
@@ -67,7 +67,6 @@ RUN set -eux; \
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
 # without specifying "--libdir", Erlang will fail during "crypto:supports()" looking for a "pthread_atfork" function that doesn't exist (but only on arm32v7/armhf??)
-	debMultiarch="$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 # OpenSSL's "config" script uses a lot of "uname"-based target detection...
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
 # https://deb.debian.org/debian/dists/unstable/main/
@@ -94,9 +93,9 @@ RUN set -eux; \
 		enable-fips \
 		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -128,8 +127,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -204,6 +203,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.11/ubuntu/Dockerfile
+++ b/3.11/ubuntu/Dockerfile
@@ -36,6 +36,10 @@ ENV OTP_VERSION 25.3.2.5
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -44,7 +48,7 @@ ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -69,11 +73,12 @@ RUN set -eux; \
 # https://deb.debian.org/debian/dists/unstable/main/
 	case "$dpkgArch" in \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
-# https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		amd64) opensslMachine='linux-x86_64' ;; \
 		arm64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://wiki.debian.org/ArchitectureSpecificsMemo#Architecture_baselines
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		i386) opensslMachine='linux-x86' ;; \
 		ppc64el) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
@@ -87,10 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="/usr/local/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="/usr/local/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -122,8 +128,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -133,19 +139,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -172,30 +179,31 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:22.04
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.12/alpine/Dockerfile
+++ b/3.12/alpine/Dockerfile
@@ -36,8 +36,8 @@ ENV OTP_VERSION 25.3.2.5
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -50,7 +50,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -92,11 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -107,7 +107,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -131,7 +131,7 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -141,7 +141,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -154,7 +154,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -180,40 +180,45 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.18
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%n#p' --recursive $ERLANG_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX \
 			| tr ',' '\n' \
 			| sort -u \
+			| grep -v '^$\|lib\(crypto\|ssl\)' \
 			| awk 'system("test -e /usr/local/lib/" $1) == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
 # Check that OpenSSL still works after copying from previous builder
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -241,11 +246,11 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION 3.12.2
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.12/alpine/Dockerfile
+++ b/3.12/alpine/Dockerfile
@@ -35,6 +35,10 @@ ENV OTP_VERSION 25.3.2.5
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -46,7 +50,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -71,8 +75,9 @@ RUN set -eux; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		aarch64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6' ;; \
-		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6+fp' ;; \
+		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		ppc64le) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
 		s390x) opensslMachine='linux64-s390x' ;; \
@@ -87,10 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir=/usr/local/lib \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath=/usr/local/lib \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -124,8 +130,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -135,19 +141,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -173,24 +180,25 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.18
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
@@ -201,10 +209,10 @@ RUN set -eux; \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
-# Check that OpenSSL still works after purging build dependencies
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+# Check that OpenSSL still works after copying from previous builder
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.12/alpine/Dockerfile
+++ b/3.12/alpine/Dockerfile
@@ -213,6 +213,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.12/ubuntu/Dockerfile
+++ b/3.12/ubuntu/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -189,7 +189,7 @@ RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [cry
 
 FROM ubuntu:22.04
 
-# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
 ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
 ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
@@ -225,8 +225,8 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION 3.12.2
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
 ENV PATH $RABBITMQ_HOME/sbin:$PATH

--- a/3.12/ubuntu/Dockerfile
+++ b/3.12/ubuntu/Dockerfile
@@ -37,8 +37,8 @@ ENV OTP_VERSION 25.3.2.5
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -48,7 +48,7 @@ ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -91,11 +91,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -127,8 +127,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$OPENSSL_INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -138,7 +138,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -151,7 +151,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -178,32 +178,36 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:22.04
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -225,7 +229,7 @@ ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.12/ubuntu/Dockerfile
+++ b/3.12/ubuntu/Dockerfile
@@ -67,7 +67,6 @@ RUN set -eux; \
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
 # without specifying "--libdir", Erlang will fail during "crypto:supports()" looking for a "pthread_atfork" function that doesn't exist (but only on arm32v7/armhf??)
-	debMultiarch="$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 # OpenSSL's "config" script uses a lot of "uname"-based target detection...
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
 # https://deb.debian.org/debian/dists/unstable/main/
@@ -94,9 +93,9 @@ RUN set -eux; \
 		enable-fips \
 		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -128,8 +127,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -204,6 +203,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.12/ubuntu/Dockerfile
+++ b/3.12/ubuntu/Dockerfile
@@ -36,6 +36,10 @@ ENV OTP_VERSION 25.3.2.5
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -44,7 +48,7 @@ ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -69,11 +73,12 @@ RUN set -eux; \
 # https://deb.debian.org/debian/dists/unstable/main/
 	case "$dpkgArch" in \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
-# https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		amd64) opensslMachine='linux-x86_64' ;; \
 		arm64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://wiki.debian.org/ArchitectureSpecificsMemo#Architecture_baselines
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		i386) opensslMachine='linux-x86' ;; \
 		ppc64el) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
@@ -87,10 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="/usr/local/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="/usr/local/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -122,8 +128,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -133,19 +139,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -172,30 +179,31 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:22.04
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.13-rc/alpine/Dockerfile
+++ b/3.13-rc/alpine/Dockerfile
@@ -36,8 +36,8 @@ ENV OTP_VERSION 26.0.2
 ENV OTP_SOURCE_SHA256="47853ea9230643a0a31004433f07a71c1b92d6e0094534f629e3b75dbc62f193"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -50,7 +50,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -92,11 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -107,7 +107,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -131,7 +131,7 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -141,7 +141,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -154,7 +154,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -180,40 +180,45 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.18
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%n#p' --recursive $ERLANG_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX \
 			| tr ',' '\n' \
 			| sort -u \
+			| grep -v '^$\|lib\(crypto\|ssl\)' \
 			| awk 'system("test -e /usr/local/lib/" $1) == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
 # Check that OpenSSL still works after copying from previous builder
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -241,11 +246,11 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION 3.13.0-beta.4
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.13-rc/alpine/Dockerfile
+++ b/3.13-rc/alpine/Dockerfile
@@ -35,6 +35,10 @@ ENV OTP_VERSION 26.0.2
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="47853ea9230643a0a31004433f07a71c1b92d6e0094534f629e3b75dbc62f193"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -46,7 +50,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -71,8 +75,9 @@ RUN set -eux; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		aarch64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6' ;; \
-		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6+fp' ;; \
+		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		ppc64le) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
 		s390x) opensslMachine='linux64-s390x' ;; \
@@ -87,10 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir=/usr/local/lib \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath=/usr/local/lib \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -124,8 +130,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -135,19 +141,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -173,24 +180,25 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.18
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
@@ -201,10 +209,10 @@ RUN set -eux; \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
-# Check that OpenSSL still works after purging build dependencies
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+# Check that OpenSSL still works after copying from previous builder
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.13-rc/alpine/Dockerfile
+++ b/3.13-rc/alpine/Dockerfile
@@ -213,6 +213,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.13-rc/ubuntu/Dockerfile
+++ b/3.13-rc/ubuntu/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -189,7 +189,7 @@ RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [cry
 
 FROM ubuntu:22.04
 
-# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
 ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
 ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
@@ -225,8 +225,8 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION 3.13.0-beta.4
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
 ENV PATH $RABBITMQ_HOME/sbin:$PATH

--- a/3.13-rc/ubuntu/Dockerfile
+++ b/3.13-rc/ubuntu/Dockerfile
@@ -37,8 +37,8 @@ ENV OTP_VERSION 26.0.2
 ENV OTP_SOURCE_SHA256="47853ea9230643a0a31004433f07a71c1b92d6e0094534f629e3b75dbc62f193"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -48,7 +48,7 @@ ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -91,11 +91,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -127,8 +127,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$OPENSSL_INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -138,7 +138,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -151,7 +151,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -178,32 +178,36 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:22.04
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -225,7 +229,7 @@ ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.13-rc/ubuntu/Dockerfile
+++ b/3.13-rc/ubuntu/Dockerfile
@@ -67,7 +67,6 @@ RUN set -eux; \
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
 # without specifying "--libdir", Erlang will fail during "crypto:supports()" looking for a "pthread_atfork" function that doesn't exist (but only on arm32v7/armhf??)
-	debMultiarch="$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 # OpenSSL's "config" script uses a lot of "uname"-based target detection...
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
 # https://deb.debian.org/debian/dists/unstable/main/
@@ -94,9 +93,9 @@ RUN set -eux; \
 		enable-fips \
 		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -128,8 +127,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -204,6 +203,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.13-rc/ubuntu/Dockerfile
+++ b/3.13-rc/ubuntu/Dockerfile
@@ -36,6 +36,10 @@ ENV OTP_VERSION 26.0.2
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="47853ea9230643a0a31004433f07a71c1b92d6e0094534f629e3b75dbc62f193"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -44,7 +48,7 @@ ENV OTP_SOURCE_SHA256="47853ea9230643a0a31004433f07a71c1b92d6e0094534f629e3b75db
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -69,11 +73,12 @@ RUN set -eux; \
 # https://deb.debian.org/debian/dists/unstable/main/
 	case "$dpkgArch" in \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
-# https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		amd64) opensslMachine='linux-x86_64' ;; \
 		arm64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://wiki.debian.org/ArchitectureSpecificsMemo#Architecture_baselines
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		i386) opensslMachine='linux-x86' ;; \
 		ppc64el) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
@@ -87,10 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="/usr/local/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="/usr/local/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -122,8 +128,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -133,19 +139,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -172,30 +179,31 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:22.04
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.9/alpine/Dockerfile
+++ b/3.9/alpine/Dockerfile
@@ -36,8 +36,8 @@ ENV OTP_VERSION 25.3.2.5
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -50,7 +50,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -92,11 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -107,7 +107,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -131,7 +131,7 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -141,7 +141,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -154,7 +154,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -180,40 +180,45 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.18
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%n#p' --recursive $ERLANG_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX \
 			| tr ',' '\n' \
 			| sort -u \
+			| grep -v '^$\|lib\(crypto\|ssl\)' \
 			| awk 'system("test -e /usr/local/lib/" $1) == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
 # Check that OpenSSL still works after copying from previous builder
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -241,11 +246,11 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION 3.9.29
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.9/alpine/Dockerfile
+++ b/3.9/alpine/Dockerfile
@@ -35,6 +35,10 @@ ENV OTP_VERSION 25.3.2.5
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -46,7 +50,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -71,8 +75,9 @@ RUN set -eux; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		aarch64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6' ;; \
-		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6+fp' ;; \
+		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		ppc64le) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
 		s390x) opensslMachine='linux64-s390x' ;; \
@@ -87,10 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir=/usr/local/lib \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath=/usr/local/lib \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -124,8 +130,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -135,19 +141,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -173,24 +180,25 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.18
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
@@ -201,10 +209,10 @@ RUN set -eux; \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
-# Check that OpenSSL still works after purging build dependencies
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+# Check that OpenSSL still works after copying from previous builder
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.9/alpine/Dockerfile
+++ b/3.9/alpine/Dockerfile
@@ -213,6 +213,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.9/ubuntu/Dockerfile
+++ b/3.9/ubuntu/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -189,7 +189,7 @@ RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [cry
 
 FROM ubuntu:22.04
 
-# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
 ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
 ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
@@ -225,8 +225,8 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION 3.9.29
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
 ENV PATH $RABBITMQ_HOME/sbin:$PATH

--- a/3.9/ubuntu/Dockerfile
+++ b/3.9/ubuntu/Dockerfile
@@ -37,8 +37,8 @@ ENV OTP_VERSION 25.3.2.5
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -48,7 +48,7 @@ ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -91,11 +91,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -127,8 +127,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$OPENSSL_INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -138,7 +138,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -151,7 +151,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -178,32 +178,36 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:22.04
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -225,7 +229,7 @@ ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/3.9/ubuntu/Dockerfile
+++ b/3.9/ubuntu/Dockerfile
@@ -67,7 +67,6 @@ RUN set -eux; \
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
 # without specifying "--libdir", Erlang will fail during "crypto:supports()" looking for a "pthread_atfork" function that doesn't exist (but only on arm32v7/armhf??)
-	debMultiarch="$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 # OpenSSL's "config" script uses a lot of "uname"-based target detection...
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
 # https://deb.debian.org/debian/dists/unstable/main/
@@ -94,9 +93,9 @@ RUN set -eux; \
 		enable-fips \
 		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -128,8 +127,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -204,6 +203,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/3.9/ubuntu/Dockerfile
+++ b/3.9/ubuntu/Dockerfile
@@ -36,6 +36,10 @@ ENV OTP_VERSION 25.3.2.5
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188cc356db"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -44,7 +48,7 @@ ENV OTP_SOURCE_SHA256="1f899b4b1ef8569c08713b76bc54607a09503a1d188e6d61512036188
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -69,11 +73,12 @@ RUN set -eux; \
 # https://deb.debian.org/debian/dists/unstable/main/
 	case "$dpkgArch" in \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
-# https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		amd64) opensslMachine='linux-x86_64' ;; \
 		arm64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://wiki.debian.org/ArchitectureSpecificsMemo#Architecture_baselines
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		i386) opensslMachine='linux-x86' ;; \
 		ppc64el) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
@@ -87,10 +92,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="/usr/local/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="/usr/local/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -122,8 +128,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -133,19 +139,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -172,30 +179,31 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:22.04
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -70,8 +70,8 @@ ENV OTP_VERSION {{ .otp.version }}
 ENV OTP_SOURCE_SHA256="{{ .otp.sha256 }}"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -84,7 +84,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -126,11 +126,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -141,7 +141,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -165,7 +165,7 @@ RUN set -eux; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -175,7 +175,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -188,7 +188,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -214,40 +214,45 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:{{ .alpine.version }}
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+		scanelf --needed --nobanner --format '%n#p' --recursive $ERLANG_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX \
 			| tr ',' '\n' \
 			| sort -u \
+			| grep -v '^$\|lib\(crypto\|ssl\)' \
 			| awk 'system("test -e /usr/local/lib/" $1) == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
 # Check that OpenSSL still works after copying from previous builder
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -275,11 +280,11 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION {{ .version }}
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -247,6 +247,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -69,6 +69,10 @@ ENV OTP_VERSION {{ .otp.version }}
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="{{ .otp.sha256 }}"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -80,7 +84,7 @@ RUN set -eux; \
 	\
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -105,8 +109,9 @@ RUN set -eux; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		aarch64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6' ;; \
-		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv6+fp' ;; \
+		armv7) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		ppc64le) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
 		s390x) opensslMachine='linux64-s390x' ;; \
@@ -121,10 +126,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir=/usr/local/lib \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath=/usr/local/lib \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -158,8 +164,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	export CFLAGS='-g -O2'; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -169,19 +175,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -207,24 +214,25 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:{{ .alpine.version }}
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Ensure run-time dependencies are installed
 	runDeps="$( \
@@ -235,10 +243,10 @@ RUN set -eux; \
 	)"; \
 	apk add --no-cache --virtual .otp-run-deps $runDeps; \
 	\
-# Check that OpenSSL still works after purging build dependencies
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+# Check that OpenSSL still works after copying from previous builder
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -71,8 +71,8 @@ ENV OTP_VERSION {{ .otp.version }}
 ENV OTP_SOURCE_SHA256="{{ .otp.sha256 }}"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -82,7 +82,7 @@ ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
+	OPENSSL_CONFIG_DIR="$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -125,11 +125,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib" \
+		--libdir="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 # add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
+		-Wl,-rpath="$OPENSSL_INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -161,8 +161,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$OPENSSL_INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$OPENSSL_INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -172,7 +172,7 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
-		--prefix="$INSTALL_PATH_PREFIX" \
+		--prefix="$ERLANG_INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
 		--disable-hipe \
@@ -185,7 +185,7 @@ RUN set -eux; \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
-		--with-ssl="$INSTALL_PATH_PREFIX" \
+		--with-ssl="$OPENSSL_INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -212,32 +212,36 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
-	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:{{ .ubuntu.version }}
 
-# INSTALL_PATH_PREFIX is in a different stage, so define it again
-ENV INSTALL_PATH_PREFIX /usr/local/erlang
-COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
-ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
+COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
+ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
-		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
-	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
-	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$OPENSSL_INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$OPENSSL_INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\
@@ -259,7 +263,7 @@ ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
 ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH=$RABBITMQ_HOME/sbin:$PATH
+ENV PATH $RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -141,7 +141,7 @@ RUN set -eux; \
 	ln -sf /etc/ssl/certs /etc/ssl/private "$OPENSSL_CONFIG_DIR"
 
 # smoke test
-RUN openssl version
+RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
 
@@ -223,7 +223,7 @@ RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [cry
 
 FROM ubuntu:{{ .ubuntu.version }}
 
-# ERLANG_INSTALL_PATH_PREFIX is in a different stage, so define it again
+# OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
 ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
 ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
@@ -259,8 +259,8 @@ RUN set -eux; \
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
 ENV RABBITMQ_VERSION {{ .version }}
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID="0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
-ENV RABBITMQ_HOME=/opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME /opt/rabbitmq
 
 # Add RabbitMQ to PATH
 ENV PATH $RABBITMQ_HOME/sbin:$PATH

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -70,6 +70,10 @@ ENV OTP_VERSION {{ .otp.version }}
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="{{ .otp.sha256 }}"
 
+# install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
+ENV INSTALL_PATH_PREFIX='/usr/local/erlang'
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
+
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
 # dpkg-dev: Required to set up host & build type when compiling Erlang/OTP
@@ -78,7 +82,7 @@ ENV OTP_SOURCE_SHA256="{{ .otp.sha256 }}"
 RUN set -eux; \
 	OPENSSL_SOURCE_URL="https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz"; \
 	OPENSSL_PATH="/usr/local/src/openssl-$OPENSSL_VERSION"; \
-	OPENSSL_CONFIG_DIR=/usr/local/etc/ssl; \
+	OPENSSL_CONFIG_DIR="$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Required by the crypto & ssl Erlang/OTP applications
 	wget --progress dot:giga --output-document "$OPENSSL_PATH.tar.gz.asc" "$OPENSSL_SOURCE_URL.asc"; \
@@ -103,11 +107,12 @@ RUN set -eux; \
 # https://deb.debian.org/debian/dists/unstable/main/
 	case "$dpkgArch" in \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
-# https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L860 (look for "linux-" and "linux64-" keys)
 		amd64) opensslMachine='linux-x86_64' ;; \
 		arm64) opensslMachine='linux-aarch64' ;; \
 # https://github.com/openssl/openssl/blob/openssl-3.1.1/Configurations/10-main.conf#L736-L766
-		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a' ;; \
+# https://wiki.debian.org/ArchitectureSpecificsMemo#Architecture_baselines
+# https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
+		armhf) opensslMachine='linux-armv4'; opensslExtraConfig='-march=armv7-a+fp' ;; \
 		i386) opensslMachine='linux-x86' ;; \
 		ppc64el) opensslMachine='linux-ppc64le' ;; \
 		riscv64) opensslMachine='linux64-riscv64' ;; \
@@ -121,10 +126,11 @@ RUN set -eux; \
 	./Configure \
 		"$opensslMachine" \
 		enable-fips \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="/usr/local/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="/usr/local/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -156,8 +162,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure /usr/local/lib/$debMultiarch is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=/usr/local/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -167,19 +173,20 @@ RUN set -eux; \
 		amd64 | arm64) jitFlag='--enable-jit' ;; \
 	esac; \
 	./configure \
+		--prefix="$INSTALL_PATH_PREFIX" \
 		--host="$hostArch" \
 		--build="$buildArch" \
-		--disable-dynamic-ssl-lib \
 		--disable-hipe \
 		--disable-sctp \
 		--disable-silent-rules \
+		--enable-builtin-zlib \
 		--enable-clock-gettime \
 		--enable-hybrid-heap \
 		--enable-kernel-poll \
-		--enable-builtin-zlib \
 		--enable-smp-support \
 		--enable-threads \
 		--with-microstate-accounting=extra \
+		--with-ssl="$INSTALL_PATH_PREFIX" \
 		--without-common_test \
 		--without-debugger \
 		--without-dialyzer \
@@ -206,30 +213,31 @@ RUN set -eux; \
 	make install; \
 	\
 # Remove unnecessary files
-	find /usr/local/lib/erlang -type d -name examples -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name src -exec rm -rf '{}' +; \
-	find /usr/local/lib/erlang -type d -name include -exec rm -rf '{}' +
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name examples -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name src -exec rm -rf '{}' +; \
+	find "$INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:{{ .ubuntu.version }}
 
-COPY --from=erlang-builder /usr/local/bin/ /usr/local/bin/
-COPY --from=erlang-builder /usr/local/etc/ssl/ /usr/local/etc/ssl/
-COPY --from=erlang-builder /usr/local/lib/ /usr/local/lib/
+# INSTALL_PATH_PREFIX is in a different stage, so define it again
+ENV INSTALL_PATH_PREFIX /usr/local/erlang
+COPY --from=erlang-builder "$INSTALL_PATH_PREFIX" "$INSTALL_PATH_PREFIX"
+ENV PATH="$INSTALL_PATH_PREFIX/bin:$PATH"
 
 ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
-	ln -vsf /etc/ssl/certs /etc/ssl/private /usr/local/etc/ssl; \
+	ln -vsf /etc/ssl/certs /etc/ssl/private "$INSTALL_PATH_PREFIX/etc/ssl"; \
 	\
 # Check that OpenSSL still works after copying from previous builder
 	ldconfig; \
-	sed -i.ORIG -e '/\.include.*fips/s/.*/.include \/usr\/local\/etc\/ssl\/fipsmodule.cnf/' \
-	    -e '/# fips =/s/.*/fips = fips_sect/' /usr/local/etc/ssl/openssl.cnf; \
-	sed -i.ORIG -e '/^activate/s/^/#/' /usr/local/etc/ssl/fipsmodule.cnf; \
+	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
+		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
+	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
 	openssl version; \
 	openssl version -d; \
 	\

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -101,7 +101,6 @@ RUN set -eux; \
 # Configure OpenSSL for compilation
 	cd "$OPENSSL_PATH"; \
 # without specifying "--libdir", Erlang will fail during "crypto:supports()" looking for a "pthread_atfork" function that doesn't exist (but only on arm32v7/armhf??)
-	debMultiarch="$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
 # OpenSSL's "config" script uses a lot of "uname"-based target detection...
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
 # https://deb.debian.org/debian/dists/unstable/main/
@@ -128,9 +127,9 @@ RUN set -eux; \
 		enable-fips \
 		--prefix="$INSTALL_PATH_PREFIX" \
 		--openssldir="$OPENSSL_CONFIG_DIR" \
-		--libdir="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib/$debMultiarch" \
+		--libdir="$INSTALL_PATH_PREFIX/lib" \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+		-Wl,-rpath="$INSTALL_PATH_PREFIX/lib" \
 		${opensslExtraConfig:-} \
 	; \
 # Compile, install OpenSSL, verify that the command-line works & development headers are present
@@ -162,8 +161,8 @@ RUN set -eux; \
 	cd "$OTP_PATH"; \
 	export ERL_TOP="$OTP_PATH"; \
 	CFLAGS="$(dpkg-buildflags --get CFLAGS)"; export CFLAGS; \
-# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib/$debMultiarch" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
-	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib/$(dpkg-architecture --query DEB_HOST_MULTIARCH)"; \
+# add -rpath to avoid conflicts between our OpenSSL's "libssl.so" and the libssl package by making sure "$INSTALL_PATH_PREFIX/lib" is searched first (but only for Erlang/OpenSSL to avoid issues with other tools using libssl; https://github.com/docker-library/rabbitmq/issues/364)
+	export CFLAGS="$CFLAGS -Wl,-rpath=$INSTALL_PATH_PREFIX/lib"; \
 	hostArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)"; \
 	buildArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	dpkgArch="$(dpkg --print-architecture)"; dpkgArch="${dpkgArch##*-}"; \
@@ -238,6 +237,7 @@ RUN set -eux; \
 	sed -i.ORIG -e "/\.include.*fips/ s!.*!.include $INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf!" \
 		-e '/# fips =/s/.*/fips = fips_sect/' "$INSTALL_PATH_PREFIX/etc/ssl/openssl.cnf"; \
 	sed -i.ORIG -e '/^activate/s/^/#/' "$INSTALL_PATH_PREFIX/etc/ssl/fipsmodule.cnf"; \
+	[ "$(command -v openssl)" = "$INSTALL_PATH_PREFIX/bin/openssl" ]; \
 	openssl version; \
 	openssl version -d; \
 	\


### PR DESCRIPTION
Fix 1: `-march=armv7-a` -> `-march=armv7-a+fp` to fix openssl build on [Debian](https://wiki.debian.org/ArchitectureSpecificsMemo#Architecture_baselines). Also applied same `+fp` to Alpine `arm32` arches, since they are also hardware float (and it might give them a speed boost). See the [GCC arm options page](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) (esp. the `-march=name` section)

```console
cc1: error: '-mfloat-abi=hard': selected architecture lacks an FPU
```
Fix 2: move custom openssl and erlang into `/usr/local/erlang` to prevent system packages from accidentally using this openssl. Once openssl compiled successfully, `wget` on `arm32v7` was unable to download the RabbitMQ release over `https` because of the custom openssl (it just happens to work fine on other architectures).

Example of the custom openssl being used where it shouldn't be:
```console
$ docker pull rabbitmq:3.9
root@fed13cf1af79:/# apt update
...
root@fed13cf1af79:/# apt install wget
...
root@fed13cf1af79:/# ldd /usr/bin/wget
...
        libssl.so.3 => /usr/local/lib/x86_64-linux-gnu/libssl.so.3 (0x00007f4b36481000)
        libcrypto.so.3 => /usr/local/lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007f4b35f51000)
...
$ # ⬆️❗⚠️ oh no 😞 
```
Fix 3: remove `disable-dynamic-ssl-lib` from erlang config. On arm32v6 (Alpine), this embedding of openssl somehow misses the dynamically linked `libatomic`, so it would fail to run. This should save a little space in every image (~10MB).

Below is the `arm32v6` failure running the image just before this [`RUN`](https://github.com/docker-library/rabbitmq/blob/274d0a537ffb64d3748bbd94064fb603b58c03ba/Dockerfile-alpine.template#L215); dropping the `-noshell` helped me figure out where the problem was and, on a whim, decided to try removing the `disable-dynamic-ssl-lib`.  Besides the smaller lib size in erlang's `crypto.so`, I'm not sure what other impact this could have (speed?).

```console
/ # erl -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:suppo
rts(), ssl:versions()]), init:stop().'
Erlang/OTP 25 [erts-13.2.2.2] [source] [32-bit] [smp:20:20] [ds:20:20:10] [async-threads:1]

Eshell V13.2.2.2  (abort with ^G)
1> =ERROR REPORT==== 24-Aug-2023::22:52:25.748301 ===
Unable to load crypto library. Failed with error:
"load_failed, Failed to load NIF library: 'Error relocating /usr/local/erlang/lib/erlang/lib/crypto-5.1.4/priv/lib/crypto.so: __atomic_fetch_or_8: symbol not found'"
OpenSSL might not be installed on this system.

=WARNING REPORT==== 24-Aug-2023::22:52:25.763412 ===
The on_load function for module crypto returned:
{error,{load_failed,"Failed to load NIF library: 'Error relocating /usr/local/erlang/lib/erlang/lib/crypto-5.1.4/priv/lib/crypto.so: __atomic_fetch_or_8: symbol not found'"}}

{"init terminating in do_boot",{undef,[{crypto,start,[],[]},{erl_eval,do_apply,7,[{file,"erl_eval.erl"},{line,744}]},{erl_eval,expr,6,[{file,"erl_eval.erl"},{line,492}]},{erl_eval,exprs,6,[{file,"erl_eval.erl"},{line,136}]},{init,start_it,1,[]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}
init terminating in do_boot ({undef,[{crypto,start,[],[]},{erl_eval,do_apply,7,[{_},{_}]},{erl_eval,expr,6,[{_},{_}]},{erl_eval,exprs,6,[{_},{_}]},{init,start_it,1,[]},{init,start_em,1,[]},{init,do_boot,3,[]}]})

Crash dump is being written to: erl_crash.dump...done
```

> `--{enable,disable}-dynamic-ssl-lib` - Enable or disable dynamic OpenSSL libraries when linking the crypto NIF. By default dynamic linking is done unless it does not work or is if it is a Windows system.
>
> \-https://www.erlang.org/doc/installation_guide/install#advanced-configuration-and-build-of-erlang-otp

Related discussion because of the failing build: https://github.com/docker-library/rabbitmq/discussions/660#discussioncomment-6753270