### PR TITLE
Added attestation from intermediate multi-stage build steps

### DIFF
--- a/3.10/alpine/Dockerfile
+++ b/3.10/alpine/Dockerfile
@@ -18,6 +18,8 @@ RUN apk add --no-cache \
 
 FROM build-base as openssl-builder
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # If you are building this image locally and are getting `gpg: keyserver receive failed: No data` errors,
@@ -110,6 +112,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 # /usr/local/src doesn't exist in Alpine by default

--- a/3.10/ubuntu/Dockerfile
+++ b/3.10/ubuntu/Dockerfile
@@ -8,6 +8,8 @@
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:22.04 as build-base
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -18,6 +20,8 @@ RUN set -eux; \
 		wget
 
 FROM build-base as openssl-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
@@ -110,6 +114,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 	OTP_SOURCE_URL="https://github.com/erlang/otp/releases/download/OTP-$OTP_VERSION/otp_src_$OTP_VERSION.tar.gz"; \

--- a/3.11/alpine/Dockerfile
+++ b/3.11/alpine/Dockerfile
@@ -18,6 +18,8 @@ RUN apk add --no-cache \
 
 FROM build-base as openssl-builder
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # If you are building this image locally and are getting `gpg: keyserver receive failed: No data` errors,
@@ -110,6 +112,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 # /usr/local/src doesn't exist in Alpine by default

--- a/3.11/ubuntu/Dockerfile
+++ b/3.11/ubuntu/Dockerfile
@@ -8,6 +8,8 @@
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:22.04 as build-base
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -18,6 +20,8 @@ RUN set -eux; \
 		wget
 
 FROM build-base as openssl-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
@@ -110,6 +114,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 	OTP_SOURCE_URL="https://github.com/erlang/otp/releases/download/OTP-$OTP_VERSION/otp_src_$OTP_VERSION.tar.gz"; \

--- a/3.12/alpine/Dockerfile
+++ b/3.12/alpine/Dockerfile
@@ -18,6 +18,8 @@ RUN apk add --no-cache \
 
 FROM build-base as openssl-builder
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # If you are building this image locally and are getting `gpg: keyserver receive failed: No data` errors,
@@ -110,6 +112,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 # /usr/local/src doesn't exist in Alpine by default

--- a/3.12/ubuntu/Dockerfile
+++ b/3.12/ubuntu/Dockerfile
@@ -8,6 +8,8 @@
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:22.04 as build-base
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -18,6 +20,8 @@ RUN set -eux; \
 		wget
 
 FROM build-base as openssl-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
@@ -110,6 +114,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 	OTP_SOURCE_URL="https://github.com/erlang/otp/releases/download/OTP-$OTP_VERSION/otp_src_$OTP_VERSION.tar.gz"; \

--- a/3.13-rc/alpine/Dockerfile
+++ b/3.13-rc/alpine/Dockerfile
@@ -18,6 +18,8 @@ RUN apk add --no-cache \
 
 FROM build-base as openssl-builder
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # If you are building this image locally and are getting `gpg: keyserver receive failed: No data` errors,
@@ -110,6 +112,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 # /usr/local/src doesn't exist in Alpine by default

--- a/3.13-rc/ubuntu/Dockerfile
+++ b/3.13-rc/ubuntu/Dockerfile
@@ -8,6 +8,8 @@
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:22.04 as build-base
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -18,6 +20,8 @@ RUN set -eux; \
 		wget
 
 FROM build-base as openssl-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
@@ -110,6 +114,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 	OTP_SOURCE_URL="https://github.com/erlang/otp/releases/download/OTP-$OTP_VERSION/otp_src_$OTP_VERSION.tar.gz"; \

--- a/3.9/alpine/Dockerfile
+++ b/3.9/alpine/Dockerfile
@@ -18,6 +18,8 @@ RUN apk add --no-cache \
 
 FROM build-base as openssl-builder
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # If you are building this image locally and are getting `gpg: keyserver receive failed: No data` errors,
@@ -110,6 +112,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 # /usr/local/src doesn't exist in Alpine by default

--- a/3.9/ubuntu/Dockerfile
+++ b/3.9/ubuntu/Dockerfile
@@ -8,6 +8,8 @@
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:22.04 as build-base
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -18,6 +20,8 @@ RUN set -eux; \
 		wget
 
 FROM build-base as openssl-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
@@ -110,6 +114,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 	OTP_SOURCE_URL="https://github.com/erlang/otp/releases/download/OTP-$OTP_VERSION/otp_src_$OTP_VERSION.tar.gz"; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -12,6 +12,8 @@ RUN apk add --no-cache \
 
 FROM build-base as openssl-builder
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # If you are building this image locally and are getting `gpg: keyserver receive failed: No data` errors,
@@ -144,6 +146,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 # /usr/local/src doesn't exist in Alpine by default

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -2,6 +2,8 @@
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:{{ .ubuntu.version }} as build-base
 
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -12,6 +14,8 @@ RUN set -eux; \
 		wget
 
 FROM build-base as openssl-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 # Default to a PGP keyserver that pgp-happy-eyeballs recognizes, but allow for substitutions locally
 ARG PGP_KEYSERVER=keyserver.ubuntu.com
@@ -144,6 +148,8 @@ RUN set -eux; \
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
 FROM openssl-builder as erlang-builder
+
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 RUN set -eux; \
 	OTP_SOURCE_URL="https://github.com/erlang/otp/releases/download/OTP-$OTP_VERSION/otp_src_$OTP_VERSION.tar.gz"; \


### PR DESCRIPTION
This is what gets added:

```
{
  ...
  "AdditionalSPDXs": [
    {
      "SPDXID": "SPDXRef-DOCUMENT",
      "creationInfo": {
        "created": "2023-09-20T19:45:23Z",
        "creators": [
          "Organization: Docker, Inc",
          "Tool: docker-scout-0.24.1-2-gd3f9c2d"
        ]
      },
      "dataLicense": "CC0-1.0",
      "documentNamespace": "https://docker.com/docker-scout/fs/sbom-build-base-8ea53ed2-8747-4506-a95c-13345f58135c",
      "name": "sbom-build-base",
      "files": [...],
      "packages": [...],
      "relationships": [...],
      "spdxVersion": "SPDX-2.3"
    },
    {
      "SPDXID": "SPDXRef-DOCUMENT",
      "creationInfo": {
        "created": "2023-09-20T19:45:24Z",
        "creators": [
          "Organization: Docker, Inc",
          "Tool: docker-scout-0.24.1-2-gd3f9c2d"
        ]
      },
      "dataLicense": "CC0-1.0",
      "documentNamespace": "https://docker.com/docker-scout/fs/sbom-erlang-builder-12ef2ee7-9522-44c7-8a04-3de591c23097",
      "name": "sbom-erlang-builder",
      "files": [...],
      "packages": [...],
      "relationships": [...],
      "spdxVersion": "SPDX-2.3"
    }
  ]
}
```