### PR TITLE
Alpine 3.20 for all RabbitMQ versions

### DIFF
--- a/3.12/alpine/Dockerfile
+++ b/3.12/alpine/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:3.19 as build-base
+FROM alpine:3.20 as build-base
 
 RUN apk add --no-cache \
 	build-base \
@@ -193,7 +193,7 @@ ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
 ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang

--- a/3.13/alpine/Dockerfile
+++ b/3.13/alpine/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:3.19 as build-base
+FROM alpine:3.20 as build-base
 
 RUN apk add --no-cache \
 	build-base \
@@ -193,7 +193,7 @@ ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
 ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
   "3.12": {
     "alpine": {
-      "version": "3.19"
+      "version": "3.20"
     },
     "openssl": {
       "sha256": "5d2be4036b478ef3cb0a854ca9b353072c3a0e26d8a56f8f0ab9fb6ed32d38d7",
@@ -19,7 +19,7 @@
   "3.12-rc": null,
   "3.13": {
     "alpine": {
-      "version": "3.19"
+      "version": "3.20"
     },
     "openssl": {
       "sha256": "5d2be4036b478ef3cb0a854ca9b353072c3a0e26d8a56f8f0ab9fb6ed32d38d7",

--- a/versions.sh
+++ b/versions.sh
@@ -2,8 +2,8 @@
 set -Eeuo pipefail
 
 declare -A alpineVersions=(
-	[3.12]='3.19'
-	[3.13]='3.19'
+	[3.12]='3.20'
+	[3.13]='3.20'
 	[4.0]='3.20'
 )
 


### PR DESCRIPTION
Switching to Alpine 3.20 as discussed in #714.