### PR TITLE
Stop using the -latest-toolchain upstream packages in 4.0

### DIFF
--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -267,7 +267,7 @@ RUN set -eux; \
 		xz \
 	; \
 	\
-	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-latest-toolchain-$RABBITMQ_VERSION.tar.xz"; \
+	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-$RABBITMQ_VERSION.tar.xz"; \
 	RABBITMQ_PATH="/usr/local/src/rabbitmq-$RABBITMQ_VERSION"; \
 	\
 	wget --output-document "$RABBITMQ_PATH.tar.xz.asc" "$RABBITMQ_SOURCE_URL.asc"; \

--- a/4.0/ubuntu/Dockerfile
+++ b/4.0/ubuntu/Dockerfile
@@ -259,7 +259,7 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-latest-toolchain-$RABBITMQ_VERSION.tar.xz"; \
+	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-$RABBITMQ_VERSION.tar.xz"; \
 	RABBITMQ_PATH="/usr/local/src/rabbitmq-$RABBITMQ_VERSION"; \
 	\
 	wget --progress dot:giga --output-document "$RABBITMQ_PATH.tar.xz.asc" "$RABBITMQ_SOURCE_URL.asc"; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -274,7 +274,7 @@ RUN set -eux; \
 		xz \
 	; \
 	\
-{{ if env.version | IN("3.13", "4.0") then ( -}}
+{{ if env.version | rtrimstr("-rc") | IN("3.13", "4.0") then ( -}}
 	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-latest-toolchain-$RABBITMQ_VERSION.tar.xz"; \
 {{ ) else ( -}}
 	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-$RABBITMQ_VERSION.tar.xz"; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -274,7 +274,7 @@ RUN set -eux; \
 		xz \
 	; \
 	\
-{{ if env.version | rtrimstr("-rc") | IN("3.13", "4.0") then ( -}}
+{{ if env.version | rtrimstr("-rc") | IN("3.13") then ( -}}
 	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-latest-toolchain-$RABBITMQ_VERSION.tar.xz"; \
 {{ ) else ( -}}
 	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-$RABBITMQ_VERSION.tar.xz"; \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -275,7 +275,7 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-{{ if env.version | IN("3.13", "4.0") then ( -}}
+{{ if env.version | rtrimstr("-rc") | IN("3.13", "4.0") then ( -}}
 	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-latest-toolchain-$RABBITMQ_VERSION.tar.xz"; \
 {{ ) else ( -}}
 	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-$RABBITMQ_VERSION.tar.xz"; \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -275,7 +275,7 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-{{ if env.version | rtrimstr("-rc") | IN("3.13", "4.0") then ( -}}
+{{ if env.version | rtrimstr("-rc") | IN("3.13") then ( -}}
 	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-latest-toolchain-$RABBITMQ_VERSION.tar.xz"; \
 {{ ) else ( -}}
 	RABBITMQ_SOURCE_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-$RABBITMQ_VERSION.tar.xz"; \


### PR DESCRIPTION
See https://github.com/docker-library/rabbitmq/issues/739#issuecomment-2495106547 (and following discussion)

This also includes #741 (since it's the same exact line, so might as well).