### PR TITLE
Fix 3.13 build failure on arm32v7 by moving to Ubuntu 24.04

### DIFF
--- a/3.13/ubuntu/Dockerfile
+++ b/3.13/ubuntu/Dockerfile
@@ -6,7 +6,7 @@
 
 # The official Canonical Ubuntu Focal image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
-FROM ubuntu:22.04 as build-base
+FROM ubuntu:24.04 as build-base
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -199,7 +199,7 @@ ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
 ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang

--- a/versions.json
+++ b/versions.json
@@ -12,7 +12,7 @@
       "version": "26.2.5.6"
     },
     "ubuntu": {
-      "version": "22.04"
+      "version": "24.04"
     },
     "version": "3.13.7"
   },

--- a/versions.sh
+++ b/versions.sh
@@ -8,7 +8,7 @@ declare -A alpineVersions=(
 )
 
 declare -A ubuntuVersions=(
-	[3.13]='22.04'
+	[3.13]='24.04'
 	[4.0]='24.04'
 	[4.1]='24.04'
 )


### PR DESCRIPTION
The `gosu` from Ubuntu 22.04 was recently [rebuilt](https://launchpad.net/ubuntu/+source/gosu/1.14-1ubuntu0.1) with go `1.18.1`. And on `arm32v7` happens to hit a regression in go (https://github.com/golang/go/issues/51776, https://github.com/golang/go/commit/4f4542479d27161d70b22557c52f182c0332ac7b). So, the build fails when it tries to `gosu nobody true`.

If we move to Ubuntu 24.04, then `gosu` will be built by a much newer golang (`~1.22`) and not have the regression from golang `1.18.1`.

Fixes https://github.com/docker-library/rabbitmq/issues/745 (This is just one option to fix it. I am open to an alternative.)

```console
+ apt-get install --yes --no-install-recommends ca-certificates gosu tzdata ...
...
+ gosu nobody true panic: unaligned 64-bit atomic operation
preempt off reason: doAllThreadsSyscall
fatal error: panic during preemptoff
```