### PR TITLE
Erlang/OTP: disable SNMP support

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -180,6 +180,7 @@ RUN set -eux; \
 		--without-observer \
 		--without-odbc \
 		--without-reltool \
+		--without-snmp \
 		--without-ssh \
 		--without-tftp \
 		--without-wx \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -188,6 +188,7 @@ RUN set -eux; \
 		--without-observer \
 		--without-odbc \
 		--without-reltool \
+		--without-snmp \
 		--without-ssh \
 		--without-tftp \
 		--without-wx \


### PR DESCRIPTION
the SNMP app is not used by RabbitMQ.

Team RabbitMQ has removed SNMP from our
zero dependency Erlang RPM to reduce the number
of dependencies with known CVEs that show up
on various scans.

A similar change was adopted by Tanzu RabbitMQ
(the commercial edition by VMware).

I suggest that the community Docker image follow
suit.