### PR TITLE
Make alias-choosing code generic so GA can be fully automated

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -53,6 +53,7 @@
     "version": "4.1.3"
   },
   "4.1-rc": null,
+  "4.2": null,
   "4.2-rc": {
     "alpine": {
       "version": "3.22"

--- a/versions.sh
+++ b/versions.sh
@@ -96,7 +96,6 @@ for version in "${versions[@]}"; do
 		if [[ "$fullVersion" == "$rcFullVersion"* ]] || [ "$latestVersion" = "$rcFullVersion" ]; then
 			# "x.y.z-rc1" == x.y.z*
 			echo >&2 "warning: skipping/removing '$version' ('$rcVersion' is at '$rcFullVersion' which is newer than '$fullVersion')"
-			json="$(jq <<<"$json" -c '.[env.version] = null')"
 			continue
 		fi
 	fi
@@ -184,6 +183,16 @@ for version in "${versions[@]}"; do
 			}
 		'
 	)"
+
+	# make sure RCs and releases have corresponding pairs
+	json="$(jq <<<"$json" -c '
+		.[
+			env.rcVersion
+			+ if env.version == env.rcVersion then
+				"-rc"
+			else "" end
+		] //= null
+	')"
 done
 
 jq <<<"$json" -S . > versions.json


### PR DESCRIPTION
This means that when 4.2 is GA, our update automation should pick it up automatically, and update `latest` and `4` to point to it.

See also discussion in https://github.com/docker-library/rabbitmq/pull/769#discussion_r2263556790