### PR TITLE
Set `RUNNING_UNDER_SYSTEMD=true` so `beam.smp` is PID 1

### DIFF
--- a/3.13/alpine/Dockerfile
+++ b/3.13/alpine/Dockerfile
@@ -317,6 +317,10 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
+# the rabbitmq-server startup script uses RUNNING_UNDER_SYSTEMD to determine if the erl command
+# should be started via exec, which results in beam.smp becoming PID 1 in the container
+ENV RUNNING_UNDER_SYSTEMD=true
+
 COPY --chown=rabbitmq:rabbitmq 10-defaults.conf 20-management_agent.disable_metrics_collector.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/3.13/ubuntu/Dockerfile
+++ b/3.13/ubuntu/Dockerfile
@@ -318,6 +318,10 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
+# the rabbitmq-server startup script uses RUNNING_UNDER_SYSTEMD to determine if the erl command
+# should be started via exec, which results in beam.smp becoming PID 1 in the container
+ENV RUNNING_UNDER_SYSTEMD=true
+
 COPY --chown=rabbitmq:rabbitmq 10-defaults.conf 20-management_agent.disable_metrics_collector.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -317,6 +317,10 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
+# the rabbitmq-server startup script uses RUNNING_UNDER_SYSTEMD to determine if the erl command
+# should be started via exec, which results in beam.smp becoming PID 1 in the container
+ENV RUNNING_UNDER_SYSTEMD=true
+
 COPY --chown=rabbitmq:rabbitmq 10-defaults.conf 20-management_agent.disable_metrics_collector.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/4.0/ubuntu/Dockerfile
+++ b/4.0/ubuntu/Dockerfile
@@ -311,6 +311,10 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
+# the rabbitmq-server startup script uses RUNNING_UNDER_SYSTEMD to determine if the erl command
+# should be started via exec, which results in beam.smp becoming PID 1 in the container
+ENV RUNNING_UNDER_SYSTEMD=true
+
 COPY --chown=rabbitmq:rabbitmq 10-defaults.conf 20-management_agent.disable_metrics_collector.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/4.1/alpine/Dockerfile
+++ b/4.1/alpine/Dockerfile
@@ -317,6 +317,10 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
+# the rabbitmq-server startup script uses RUNNING_UNDER_SYSTEMD to determine if the erl command
+# should be started via exec, which results in beam.smp becoming PID 1 in the container
+ENV RUNNING_UNDER_SYSTEMD=true
+
 COPY --chown=rabbitmq:rabbitmq 10-defaults.conf 20-management_agent.disable_metrics_collector.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/4.1/ubuntu/Dockerfile
+++ b/4.1/ubuntu/Dockerfile
@@ -311,6 +311,10 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
+# the rabbitmq-server startup script uses RUNNING_UNDER_SYSTEMD to determine if the erl command
+# should be started via exec, which results in beam.smp becoming PID 1 in the container
+ENV RUNNING_UNDER_SYSTEMD=true
+
 COPY --chown=rabbitmq:rabbitmq 10-defaults.conf 20-management_agent.disable_metrics_collector.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/4.2/alpine/Dockerfile
+++ b/4.2/alpine/Dockerfile
@@ -317,6 +317,10 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
+# the rabbitmq-server startup script uses RUNNING_UNDER_SYSTEMD to determine if the erl command
+# should be started via exec, which results in beam.smp becoming PID 1 in the container
+ENV RUNNING_UNDER_SYSTEMD=true
+
 COPY --chown=rabbitmq:rabbitmq 10-defaults.conf 20-management_agent.disable_metrics_collector.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/4.2/ubuntu/Dockerfile
+++ b/4.2/ubuntu/Dockerfile
@@ -311,6 +311,10 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
+# the rabbitmq-server startup script uses RUNNING_UNDER_SYSTEMD to determine if the erl command
+# should be started via exec, which results in beam.smp becoming PID 1 in the container
+ENV RUNNING_UNDER_SYSTEMD=true
+
 COPY --chown=rabbitmq:rabbitmq 10-defaults.conf 20-management_agent.disable_metrics_collector.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -324,6 +324,10 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
+# the rabbitmq-server startup script uses RUNNING_UNDER_SYSTEMD to determine if the erl command
+# should be started via exec, which results in beam.smp becoming PID 1 in the container
+ENV RUNNING_UNDER_SYSTEMD=true
+
 COPY --chown=rabbitmq:rabbitmq 10-defaults.conf 20-management_agent.disable_metrics_collector.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -327,6 +327,10 @@ VOLUME $RABBITMQ_DATA_DIR
 # https://docs.docker.com/samples/library/ubuntu/#locales
 ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
 
+# the rabbitmq-server startup script uses RUNNING_UNDER_SYSTEMD to determine if the erl command
+# should be started via exec, which results in beam.smp becoming PID 1 in the container
+ENV RUNNING_UNDER_SYSTEMD=true
+
 COPY --chown=rabbitmq:rabbitmq 10-defaults.conf 20-management_agent.disable_metrics_collector.conf /etc/rabbitmq/conf.d/
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
The current Dockerfile / docker-entrypoint.sh results in the following PIDs within a running RabbitMQ container:

```
PID CMD
  1 /bin/sh /opt/rabbitmq/sbin/rabbitmq-server
 20 /opt/erlang/lib/erlang/erts-15.2.7.4/bin/beam.smp -W w ...
 26 erl_child_setup 1024
 65 /opt/erlang/lib/erlang/erts-15.2.7.4/bin/inet_gethost 4
 66 /opt/erlang/lib/erlang/erts-15.2.7.4/bin/inet_gethost 4
 76 /opt/erlang/lib/erlang/erts-15.2.7.4/bin/epmd -daemon
121 /bin/sh -s rabbit_disk_monitor
```

Note that the `rabbitmq-server` script remains running and is PID 1.

There was a [long discussion](https://github.com/rabbitmq/cluster-operator/discussions/2012) about what results this particular setup could have in heavily-loaded k8s environments. This prompted me to look at the `rabbitmq-server` script and found that the behavior can be controlled via several env variables:

https://github.com/rabbitmq/rabbitmq-server/blob/ad3fccf5ebea55c85730cf0466918e252cebdd0d/deps/rabbit/scripts/rabbitmq-server#L97

Most notably, if `RUNNING_UNDER_SYSTEMD` is set to a value, the script will `exec` the Erlang VM. This PR sets that value, which results in the following PIDs in a container:

```
PID CMD
  1 /opt/erlang/lib/erlang/erts-15.2.7.4/bin/beam.smp -W w ...
 25 erl_child_setup 1024
 64 /opt/erlang/lib/erlang/erts-15.2.7.4/bin/inet_gethost 4
 65 /opt/erlang/lib/erlang/erts-15.2.7.4/bin/inet_gethost 4
 75 /opt/erlang/lib/erlang/erts-15.2.7.4/bin/epmd -daemon
120 /bin/sh -s rabbit_disk_monitor
```

The Erlang VM already gracefully stops RabbitMQ on `SIGTERM`, so there is no change in behavior.