### PR TITLE
Address build warnings

### DIFF
--- a/3.13/alpine/Dockerfile
+++ b/3.13/alpine/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #
@@ -5,7 +7,7 @@
 #
 
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:3.22 as build-base
+FROM alpine:3.22 AS build-base
 
 RUN apk add --no-cache \
 	build-base \
@@ -16,7 +18,7 @@ RUN apk add --no-cache \
 	linux-headers \
 	ncurses-dev
 
-FROM build-base as openssl-builder
+FROM build-base AS openssl-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -26,19 +28,19 @@ ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:3.13 --build-arg PGP_KEYSERVER=pgpkeys.eu 3.13/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-ENV OPENSSL_VERSION 3.1.8
+ENV OPENSSL_VERSION=3.1.8
 ENV OPENSSL_SOURCE_SHA256="d319da6aecde3aa6f426b44bbf997406d95275c5c59ab6f6ef53caaa079f456f"
 # https://www.openssl.org/source/
 ENV OPENSSL_PGP_KEY_IDS="0xBA5473A2B0587B07FB27CF2D216094DFD0CB81EF"
 
-ENV OTP_VERSION 26.2.5.16
+ENV OTP_VERSION=26.2.5.16
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="932d091933f818d89c2cf7a8c23d84781bbae4b1ee7b846e8676e22768570cae"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -110,7 +112,7 @@ RUN set -eux; \
 # smoke test
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
-FROM openssl-builder as erlang-builder
+FROM openssl-builder AS erlang-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -189,22 +191,22 @@ RUN set -eux; \
 	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.22
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
 COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
 
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
@@ -250,13 +252,13 @@ RUN set -eux; \
 		tzdata
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION 3.13.7
+ENV RABBITMQ_VERSION=3.13.7
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
-ENV RABBITMQ_HOME /opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID=0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH $RABBITMQ_HOME/sbin:$PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -308,7 +310,7 @@ RUN su-exec rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
-ENV HOME $RABBITMQ_DATA_DIR
+ENV HOME=$RABBITMQ_DATA_DIR
 # Hint that the data (a.k.a. home dir) dir should be separate volume
 VOLUME $RABBITMQ_DATA_DIR
 

--- a/3.13/alpine/management/Dockerfile
+++ b/3.13/alpine/management/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #

--- a/3.13/ubuntu/Dockerfile
+++ b/3.13/ubuntu/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #
@@ -6,7 +8,7 @@
 
 # The official Canonical Ubuntu Focal image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
-FROM ubuntu:24.04 as build-base
+FROM ubuntu:24.04 AS build-base
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -19,7 +21,7 @@ RUN set -eux; \
 		libncurses5-dev \
 		wget
 
-FROM build-base as openssl-builder
+FROM build-base AS openssl-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -29,19 +31,19 @@ ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:3.13 --build-arg PGP_KEYSERVER=pgpkeys.eu 3.13/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-ENV OPENSSL_VERSION 3.1.8
+ENV OPENSSL_VERSION=3.1.8
 ENV OPENSSL_SOURCE_SHA256="d319da6aecde3aa6f426b44bbf997406d95275c5c59ab6f6ef53caaa079f456f"
 # https://www.openssl.org/source/
 ENV OPENSSL_PGP_KEY_IDS="0xBA5473A2B0587B07FB27CF2D216094DFD0CB81EF"
 
-ENV OTP_VERSION 26.2.5.16
+ENV OTP_VERSION=26.2.5.16
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="932d091933f818d89c2cf7a8c23d84781bbae4b1ee7b846e8676e22768570cae"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -112,7 +114,7 @@ RUN set -eux; \
 # smoke test
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
-FROM openssl-builder as erlang-builder
+FROM openssl-builder AS erlang-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -196,21 +198,21 @@ RUN set -eux; \
 	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:24.04
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
 COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
 
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
@@ -237,13 +239,13 @@ RUN set -eux; \
 	ln -sf "$RABBITMQ_DATA_DIR/.erlang.cookie" /root/.erlang.cookie
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION 3.13.7
+ENV RABBITMQ_VERSION=3.13.7
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
-ENV RABBITMQ_HOME /opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID=0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH $RABBITMQ_HOME/sbin:$PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -309,7 +311,7 @@ RUN gosu rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
-ENV HOME $RABBITMQ_DATA_DIR
+ENV HOME=$RABBITMQ_DATA_DIR
 # Hint that the data (a.k.a. home dir) dir should be separate volume
 VOLUME $RABBITMQ_DATA_DIR
 

--- a/3.13/ubuntu/management/Dockerfile
+++ b/3.13/ubuntu/management/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #

--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #
@@ -5,7 +7,7 @@
 #
 
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:3.22 as build-base
+FROM alpine:3.22 AS build-base
 
 RUN apk add --no-cache \
 	build-base \
@@ -16,7 +18,7 @@ RUN apk add --no-cache \
 	linux-headers \
 	ncurses-dev
 
-FROM build-base as openssl-builder
+FROM build-base AS openssl-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -26,19 +28,19 @@ ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:4.0 --build-arg PGP_KEYSERVER=pgpkeys.eu 4.0/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-ENV OPENSSL_VERSION 3.5.4
+ENV OPENSSL_VERSION=3.5.4
 ENV OPENSSL_SOURCE_SHA256="967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99"
 # https://www.openssl.org/source/
 ENV OPENSSL_PGP_KEY_IDS="0xBA5473A2B0587B07FB27CF2D216094DFD0CB81EF"
 
-ENV OTP_VERSION 27.3.4.6
+ENV OTP_VERSION=27.3.4.6
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="658529f94cc5b8833907aa680a5e979e67c32dd6ebba69ed3b90b95f526ccda2"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -110,7 +112,7 @@ RUN set -eux; \
 # smoke test
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
-FROM openssl-builder as erlang-builder
+FROM openssl-builder AS erlang-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -189,22 +191,22 @@ RUN set -eux; \
 	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.22
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
 COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
 
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
@@ -250,13 +252,13 @@ RUN set -eux; \
 		tzdata
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION 4.0.9
+ENV RABBITMQ_VERSION=4.0.9
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
-ENV RABBITMQ_HOME /opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID=0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH $RABBITMQ_HOME/sbin:$PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -308,7 +310,7 @@ RUN su-exec rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
-ENV HOME $RABBITMQ_DATA_DIR
+ENV HOME=$RABBITMQ_DATA_DIR
 # Hint that the data (a.k.a. home dir) dir should be separate volume
 VOLUME $RABBITMQ_DATA_DIR
 

--- a/4.0/alpine/management/Dockerfile
+++ b/4.0/alpine/management/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #

--- a/4.0/ubuntu/Dockerfile
+++ b/4.0/ubuntu/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #
@@ -6,7 +8,7 @@
 
 # The official Canonical Ubuntu Focal image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
-FROM ubuntu:24.04 as build-base
+FROM ubuntu:24.04 AS build-base
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -19,7 +21,7 @@ RUN set -eux; \
 		libncurses5-dev \
 		wget
 
-FROM build-base as openssl-builder
+FROM build-base AS openssl-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -29,19 +31,19 @@ ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:4.0 --build-arg PGP_KEYSERVER=pgpkeys.eu 4.0/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-ENV OPENSSL_VERSION 3.5.4
+ENV OPENSSL_VERSION=3.5.4
 ENV OPENSSL_SOURCE_SHA256="967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99"
 # https://www.openssl.org/source/
 ENV OPENSSL_PGP_KEY_IDS="0xBA5473A2B0587B07FB27CF2D216094DFD0CB81EF"
 
-ENV OTP_VERSION 27.3.4.6
+ENV OTP_VERSION=27.3.4.6
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="658529f94cc5b8833907aa680a5e979e67c32dd6ebba69ed3b90b95f526ccda2"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -112,7 +114,7 @@ RUN set -eux; \
 # smoke test
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
-FROM openssl-builder as erlang-builder
+FROM openssl-builder AS erlang-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -189,21 +191,21 @@ RUN set -eux; \
 	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:24.04
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
 COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
 
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
@@ -230,13 +232,13 @@ RUN set -eux; \
 	ln -sf "$RABBITMQ_DATA_DIR/.erlang.cookie" /root/.erlang.cookie
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION 4.0.9
+ENV RABBITMQ_VERSION=4.0.9
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
-ENV RABBITMQ_HOME /opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID=0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH $RABBITMQ_HOME/sbin:$PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -302,7 +304,7 @@ RUN gosu rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
-ENV HOME $RABBITMQ_DATA_DIR
+ENV HOME=$RABBITMQ_DATA_DIR
 # Hint that the data (a.k.a. home dir) dir should be separate volume
 VOLUME $RABBITMQ_DATA_DIR
 

--- a/4.0/ubuntu/management/Dockerfile
+++ b/4.0/ubuntu/management/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #

--- a/4.1/alpine/Dockerfile
+++ b/4.1/alpine/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #
@@ -5,7 +7,7 @@
 #
 
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:3.22 as build-base
+FROM alpine:3.22 AS build-base
 
 RUN apk add --no-cache \
 	build-base \
@@ -16,7 +18,7 @@ RUN apk add --no-cache \
 	linux-headers \
 	ncurses-dev
 
-FROM build-base as openssl-builder
+FROM build-base AS openssl-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -26,19 +28,19 @@ ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:4.1 --build-arg PGP_KEYSERVER=pgpkeys.eu 4.1/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-ENV OPENSSL_VERSION 3.5.4
+ENV OPENSSL_VERSION=3.5.4
 ENV OPENSSL_SOURCE_SHA256="967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99"
 # https://www.openssl.org/source/
 ENV OPENSSL_PGP_KEY_IDS="0xBA5473A2B0587B07FB27CF2D216094DFD0CB81EF"
 
-ENV OTP_VERSION 27.3.4.6
+ENV OTP_VERSION=27.3.4.6
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="658529f94cc5b8833907aa680a5e979e67c32dd6ebba69ed3b90b95f526ccda2"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -110,7 +112,7 @@ RUN set -eux; \
 # smoke test
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
-FROM openssl-builder as erlang-builder
+FROM openssl-builder AS erlang-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -189,22 +191,22 @@ RUN set -eux; \
 	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.22
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
 COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
 
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
@@ -250,13 +252,13 @@ RUN set -eux; \
 		tzdata
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION 4.1.6
+ENV RABBITMQ_VERSION=4.1.6
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
-ENV RABBITMQ_HOME /opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID=0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH $RABBITMQ_HOME/sbin:$PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -308,7 +310,7 @@ RUN su-exec rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
-ENV HOME $RABBITMQ_DATA_DIR
+ENV HOME=$RABBITMQ_DATA_DIR
 # Hint that the data (a.k.a. home dir) dir should be separate volume
 VOLUME $RABBITMQ_DATA_DIR
 

--- a/4.1/alpine/management/Dockerfile
+++ b/4.1/alpine/management/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #

--- a/4.1/ubuntu/Dockerfile
+++ b/4.1/ubuntu/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #
@@ -6,7 +8,7 @@
 
 # The official Canonical Ubuntu Focal image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
-FROM ubuntu:24.04 as build-base
+FROM ubuntu:24.04 AS build-base
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -19,7 +21,7 @@ RUN set -eux; \
 		libncurses5-dev \
 		wget
 
-FROM build-base as openssl-builder
+FROM build-base AS openssl-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -29,19 +31,19 @@ ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:4.1 --build-arg PGP_KEYSERVER=pgpkeys.eu 4.1/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-ENV OPENSSL_VERSION 3.5.4
+ENV OPENSSL_VERSION=3.5.4
 ENV OPENSSL_SOURCE_SHA256="967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99"
 # https://www.openssl.org/source/
 ENV OPENSSL_PGP_KEY_IDS="0xBA5473A2B0587B07FB27CF2D216094DFD0CB81EF"
 
-ENV OTP_VERSION 27.3.4.6
+ENV OTP_VERSION=27.3.4.6
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="658529f94cc5b8833907aa680a5e979e67c32dd6ebba69ed3b90b95f526ccda2"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -112,7 +114,7 @@ RUN set -eux; \
 # smoke test
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
-FROM openssl-builder as erlang-builder
+FROM openssl-builder AS erlang-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -189,21 +191,21 @@ RUN set -eux; \
 	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:24.04
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
 COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
 
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
@@ -230,13 +232,13 @@ RUN set -eux; \
 	ln -sf "$RABBITMQ_DATA_DIR/.erlang.cookie" /root/.erlang.cookie
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION 4.1.6
+ENV RABBITMQ_VERSION=4.1.6
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
-ENV RABBITMQ_HOME /opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID=0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH $RABBITMQ_HOME/sbin:$PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -302,7 +304,7 @@ RUN gosu rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
-ENV HOME $RABBITMQ_DATA_DIR
+ENV HOME=$RABBITMQ_DATA_DIR
 # Hint that the data (a.k.a. home dir) dir should be separate volume
 VOLUME $RABBITMQ_DATA_DIR
 

--- a/4.1/ubuntu/management/Dockerfile
+++ b/4.1/ubuntu/management/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #

--- a/4.2/alpine/Dockerfile
+++ b/4.2/alpine/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #
@@ -5,7 +7,7 @@
 #
 
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:3.22 as build-base
+FROM alpine:3.22 AS build-base
 
 RUN apk add --no-cache \
 	build-base \
@@ -16,7 +18,7 @@ RUN apk add --no-cache \
 	linux-headers \
 	ncurses-dev
 
-FROM build-base as openssl-builder
+FROM build-base AS openssl-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -26,19 +28,19 @@ ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:4.2 --build-arg PGP_KEYSERVER=pgpkeys.eu 4.2/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-ENV OPENSSL_VERSION 3.5.4
+ENV OPENSSL_VERSION=3.5.4
 ENV OPENSSL_SOURCE_SHA256="967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99"
 # https://www.openssl.org/source/
 ENV OPENSSL_PGP_KEY_IDS="0xBA5473A2B0587B07FB27CF2D216094DFD0CB81EF"
 
-ENV OTP_VERSION 27.3.4.6
+ENV OTP_VERSION=27.3.4.6
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="658529f94cc5b8833907aa680a5e979e67c32dd6ebba69ed3b90b95f526ccda2"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -110,7 +112,7 @@ RUN set -eux; \
 # smoke test
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
-FROM openssl-builder as erlang-builder
+FROM openssl-builder AS erlang-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -189,22 +191,22 @@ RUN set -eux; \
 	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:3.22
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
 COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
 
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
@@ -250,13 +252,13 @@ RUN set -eux; \
 		tzdata
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION 4.2.1
+ENV RABBITMQ_VERSION=4.2.1
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
-ENV RABBITMQ_HOME /opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID=0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH $RABBITMQ_HOME/sbin:$PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -308,7 +310,7 @@ RUN su-exec rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
-ENV HOME $RABBITMQ_DATA_DIR
+ENV HOME=$RABBITMQ_DATA_DIR
 # Hint that the data (a.k.a. home dir) dir should be separate volume
 VOLUME $RABBITMQ_DATA_DIR
 

--- a/4.2/alpine/management/Dockerfile
+++ b/4.2/alpine/management/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #

--- a/4.2/ubuntu/Dockerfile
+++ b/4.2/ubuntu/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #
@@ -6,7 +8,7 @@
 
 # The official Canonical Ubuntu Focal image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
-FROM ubuntu:24.04 as build-base
+FROM ubuntu:24.04 AS build-base
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -19,7 +21,7 @@ RUN set -eux; \
 		libncurses5-dev \
 		wget
 
-FROM build-base as openssl-builder
+FROM build-base AS openssl-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -29,19 +31,19 @@ ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:4.2 --build-arg PGP_KEYSERVER=pgpkeys.eu 4.2/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-ENV OPENSSL_VERSION 3.5.4
+ENV OPENSSL_VERSION=3.5.4
 ENV OPENSSL_SOURCE_SHA256="967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99"
 # https://www.openssl.org/source/
 ENV OPENSSL_PGP_KEY_IDS="0xBA5473A2B0587B07FB27CF2D216094DFD0CB81EF"
 
-ENV OTP_VERSION 27.3.4.6
+ENV OTP_VERSION=27.3.4.6
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="658529f94cc5b8833907aa680a5e979e67c32dd6ebba69ed3b90b95f526ccda2"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -112,7 +114,7 @@ RUN set -eux; \
 # smoke test
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
-FROM openssl-builder as erlang-builder
+FROM openssl-builder AS erlang-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -189,21 +191,21 @@ RUN set -eux; \
 	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:24.04
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
 COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
 
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
@@ -230,13 +232,13 @@ RUN set -eux; \
 	ln -sf "$RABBITMQ_DATA_DIR/.erlang.cookie" /root/.erlang.cookie
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION 4.2.1
+ENV RABBITMQ_VERSION=4.2.1
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
-ENV RABBITMQ_HOME /opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID=0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH $RABBITMQ_HOME/sbin:$PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -302,7 +304,7 @@ RUN gosu rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
-ENV HOME $RABBITMQ_DATA_DIR
+ENV HOME=$RABBITMQ_DATA_DIR
 # Hint that the data (a.k.a. home dir) dir should be separate volume
 VOLUME $RABBITMQ_DATA_DIR
 

--- a/4.2/ubuntu/management/Dockerfile
+++ b/4.2/ubuntu/management/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+# check=skip=SecretsUsedInArgOrEnv
 #
 # NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 #

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,5 +1,5 @@
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
-FROM alpine:{{ .alpine.version }} as build-base
+FROM alpine:{{ .alpine.version }} AS build-base
 
 RUN apk add --no-cache \
 	build-base \
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
 	linux-headers \
 	ncurses-dev
 
-FROM build-base as openssl-builder
+FROM build-base AS openssl-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -20,7 +20,7 @@ ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:{{ env.version }} --build-arg PGP_KEYSERVER=pgpkeys.eu {{ env.version }}/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-ENV OPENSSL_VERSION {{ .openssl.version }}
+ENV OPENSSL_VERSION={{ .openssl.version }}
 ENV OPENSSL_SOURCE_SHA256="{{ .openssl.sha256 }}"
 # https://www.openssl.org/source/
 ENV OPENSSL_PGP_KEY_IDS="{{
@@ -38,14 +38,14 @@ ENV OPENSSL_PGP_KEY_IDS="{{
 | map("0x" + gsub(" "; "")) | join(" ")
 }}"
 
-ENV OTP_VERSION {{ .otp.version }}
+ENV OTP_VERSION={{ .otp.version }}
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="{{ .otp.sha256 }}"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -117,7 +117,7 @@ RUN set -eux; \
 # smoke test
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
-FROM openssl-builder as erlang-builder
+FROM openssl-builder AS erlang-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -196,22 +196,22 @@ RUN set -eux; \
 	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM alpine:{{ .alpine.version }}
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
 COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
 
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
@@ -257,13 +257,13 @@ RUN set -eux; \
 		tzdata
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION {{ .version }}
+ENV RABBITMQ_VERSION={{ .version }}
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
-ENV RABBITMQ_HOME /opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID=0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH $RABBITMQ_HOME/sbin:$PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -315,7 +315,7 @@ RUN su-exec rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
-ENV HOME $RABBITMQ_DATA_DIR
+ENV HOME=$RABBITMQ_DATA_DIR
 # Hint that the data (a.k.a. home dir) dir should be separate volume
 VOLUME $RABBITMQ_DATA_DIR
 

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -1,6 +1,6 @@
 # The official Canonical Ubuntu Focal image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
-FROM ubuntu:{{ .ubuntu.version }} as build-base
+FROM ubuntu:{{ .ubuntu.version }} AS build-base
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -13,7 +13,7 @@ RUN set -eux; \
 		libncurses5-dev \
 		wget
 
-FROM build-base as openssl-builder
+FROM build-base AS openssl-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -23,7 +23,7 @@ ARG PGP_KEYSERVER=keyserver.ubuntu.com
 # run the build with a different PGP_KEYSERVER, e.g. docker build --tag rabbitmq:{{ env.version }} --build-arg PGP_KEYSERVER=pgpkeys.eu {{ env.version }}/ubuntu
 # For context, see https://github.com/docker-library/official-images/issues/4252
 
-ENV OPENSSL_VERSION {{ .openssl.version }}
+ENV OPENSSL_VERSION={{ .openssl.version }}
 ENV OPENSSL_SOURCE_SHA256="{{ .openssl.sha256 }}"
 # https://www.openssl.org/source/
 ENV OPENSSL_PGP_KEY_IDS="{{
@@ -41,14 +41,14 @@ ENV OPENSSL_PGP_KEY_IDS="{{
 | map("0x" + gsub(" "; "")) | join(" ")
 }}"
 
-ENV OTP_VERSION {{ .otp.version }}
+ENV OTP_VERSION={{ .otp.version }}
 # TODO add PGP checking when the feature will be added to Erlang/OTP's build system
 # https://erlang.org/pipermail/erlang-questions/2019-January/097067.html
 ENV OTP_SOURCE_SHA256="{{ .otp.sha256 }}"
 
 # install openssl & erlang to a path that isn't auto-checked for libs to prevent accidental use by system packages
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 
 # Install dependencies required to build Erlang/OTP from source
 # https://erlang.org/doc/installation_guide/INSTALL.html
@@ -119,7 +119,7 @@ RUN set -eux; \
 # smoke test
 RUN $OPENSSL_INSTALL_PATH_PREFIX/bin/openssl version
 
-FROM openssl-builder as erlang-builder
+FROM openssl-builder AS erlang-builder
 
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
@@ -205,21 +205,21 @@ RUN set -eux; \
 	find "$ERLANG_INSTALL_PATH_PREFIX/lib/erlang" -type d -name include -exec rm -rf '{}' +
 
 # Check that Erlang/OTP crypto & ssl were compiled against OpenSSL correctly
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$PATH
 RUN find $ERLANG_INSTALL_PATH_PREFIX -type f -name 'crypto.so' -exec ldd {} \; | awk '/libcrypto\.so/ { if (!index($3,ENVIRON["OPENSSL_INSTALL_PATH_PREFIX"])) exit 1 }'
 RUN erl -noshell -eval 'ok = crypto:start(), ok = io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
 
 FROM ubuntu:{{ .ubuntu.version }}
 
 # OPENSSL/ERLANG_INSTALL_PATH_PREFIX are defined in a different stage, so define them again
-ENV ERLANG_INSTALL_PATH_PREFIX /opt/erlang
-ENV OPENSSL_INSTALL_PATH_PREFIX /opt/openssl
+ENV ERLANG_INSTALL_PATH_PREFIX=/opt/erlang
+ENV OPENSSL_INSTALL_PATH_PREFIX=/opt/openssl
 COPY --from=erlang-builder $ERLANG_INSTALL_PATH_PREFIX $ERLANG_INSTALL_PATH_PREFIX
 COPY --from=openssl-builder $OPENSSL_INSTALL_PATH_PREFIX $OPENSSL_INSTALL_PATH_PREFIX
 
-ENV PATH $ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
+ENV PATH=$ERLANG_INSTALL_PATH_PREFIX/bin:$OPENSSL_INSTALL_PATH_PREFIX/bin:$PATH
 
-ENV RABBITMQ_DATA_DIR /var/lib/rabbitmq
+ENV RABBITMQ_DATA_DIR=/var/lib/rabbitmq
 
 RUN set -eux; \
 # Configure OpenSSL to use system certs
@@ -246,13 +246,13 @@ RUN set -eux; \
 	ln -sf "$RABBITMQ_DATA_DIR/.erlang.cookie" /root/.erlang.cookie
 
 # Use the latest stable RabbitMQ release (https://www.rabbitmq.com/download.html)
-ENV RABBITMQ_VERSION {{ .version }}
+ENV RABBITMQ_VERSION={{ .version }}
 # https://www.rabbitmq.com/signatures.html#importing-gpg
-ENV RABBITMQ_PGP_KEY_ID 0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
-ENV RABBITMQ_HOME /opt/rabbitmq
+ENV RABBITMQ_PGP_KEY_ID=0x0A9AF2115F4687BD29803A206B73A36E6026DFCA
+ENV RABBITMQ_HOME=/opt/rabbitmq
 
 # Add RabbitMQ to PATH
-ENV PATH $RABBITMQ_HOME/sbin:$PATH
+ENV PATH=$RABBITMQ_HOME/sbin:$PATH
 
 # Install RabbitMQ
 RUN set -eux; \
@@ -318,7 +318,7 @@ RUN gosu rabbitmq rabbitmq-plugins enable --offline rabbitmq_prometheus
 RUN ln -sf /opt/rabbitmq/plugins /plugins
 
 # set home so that any `--user` knows where to put the erlang cookie
-ENV HOME $RABBITMQ_DATA_DIR
+ENV HOME=$RABBITMQ_DATA_DIR
 # Hint that the data (a.k.a. home dir) dir should be separate volume
 VOLUME $RABBITMQ_DATA_DIR
 

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -20,6 +20,8 @@ fi
 
 generated_warning() {
 	cat <<-EOH
+		# syntax=docker/dockerfile:1
+		# check=skip=SecretsUsedInArgOrEnv
 		#
 		# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
 		#


### PR DESCRIPTION
The following warnings are emitted by `docker build`:

```
 19 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 204)
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "RABBITMQ_PGP_KEY_ID") (line 235)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 239)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 9)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 32)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 199)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 206)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 235)
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "OPENSSL_PGP_KEY_IDS") (line 35)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 37)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 43)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 44)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 233)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 236)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 305)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 22)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 192)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 200)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 115)
```

This PR addresses them.