### PR TITLE
Add Rust-based `rabbitmqadmin-ng` and remove Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+*.tar.gz
+*.zip
+rustup-init.sh
 .jq-template.awk

--- a/3.13/alpine/Dockerfile
+++ b/3.13/alpine/Dockerfile
@@ -6,6 +6,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
 FROM alpine:3.22 AS build-base
 

--- a/3.13/alpine/management/Dockerfile
+++ b/3.13/alpine/management/Dockerfile
@@ -6,18 +6,30 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
+FROM rabbitmq:3.13-alpine AS builder
+
+RUN set -eux; \
+	echo "[INFO] rabbitmqadmin is not available on Alpine Linux"
+
+RUN touch /usr/local/bin/rabbitmqadmin
+
 FROM rabbitmq:3.13-alpine
 
 RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_management; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
-	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf; \
-# grab "rabbitmqadmin" from inside the "rabbitmq_management-X.Y.Z" plugin folder
-# see https://github.com/docker-library/rabbitmq/issues/207
-	cp /plugins/rabbitmq_management-*/priv/www/cli/rabbitmqadmin /usr/local/bin/rabbitmqadmin; \
-	[ -s /usr/local/bin/rabbitmqadmin ]; \
-	chmod +x /usr/local/bin/rabbitmqadmin; \
-	apk add --no-cache python3; \
-	rabbitmqadmin --version
+	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
+
+COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
+
+RUN set -eux; \
+	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
+		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
+		rabbitmqadmin --help; \
+	else \
+		rm -f /tmp/rabbitmqadmin-rust; \
+		echo "[INFO] rabbitmqadmin is not available on this platform."; \
+	fi
 
 EXPOSE 15671 15672

--- a/3.13/ubuntu/Dockerfile
+++ b/3.13/ubuntu/Dockerfile
@@ -6,6 +6,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
 # The official Canonical Ubuntu Focal image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:24.04 AS build-base

--- a/3.13/ubuntu/management/Dockerfile
+++ b/3.13/ubuntu/management/Dockerfile
@@ -6,20 +6,42 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
+FROM rabbitmq:3.13 AS builder
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	arch="$(uname -m)"; \
+	if [ "$arch" = "x86_64" ]; then \
+		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"; \
+		echo "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
+	elif [ "$arch" = "aarch64" ]; then  \
+		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"; \
+		echo "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4 /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
+	else \
+		echo "[INFO] rabbitmqadmin is not available on Ubuntu $arch"; \
+	fi; \
+	chmod +x /usr/local/bin/rabbitmqadmin
+
+RUN touch /usr/local/bin/rabbitmqadmin
+
 FROM rabbitmq:3.13
 
 RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_management; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
-	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf; \
-# grab "rabbitmqadmin" from inside the "rabbitmq_management-X.Y.Z" plugin folder
-# see https://github.com/docker-library/rabbitmq/issues/207
-	cp /plugins/rabbitmq_management-*/priv/www/cli/rabbitmqadmin /usr/local/bin/rabbitmqadmin; \
-	[ -s /usr/local/bin/rabbitmqadmin ]; \
-	chmod +x /usr/local/bin/rabbitmqadmin; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends python3; \
-	rm -rf /var/lib/apt/lists/*; \
-	rabbitmqadmin --version
+	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
+
+COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
+
+RUN set -eux; \
+	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
+		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
+		rabbitmqadmin --help; \
+	else \
+		rm -f /tmp/rabbitmqadmin-rust; \
+		echo "[INFO] rabbitmqadmin is not available on this platform."; \
+	fi
 
 EXPOSE 15671 15672

--- a/4.0/alpine/Dockerfile
+++ b/4.0/alpine/Dockerfile
@@ -6,6 +6,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
 FROM alpine:3.22 AS build-base
 

--- a/4.0/alpine/management/Dockerfile
+++ b/4.0/alpine/management/Dockerfile
@@ -6,18 +6,30 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
+FROM rabbitmq:4.0-alpine AS builder
+
+RUN set -eux; \
+	echo "[INFO] rabbitmqadmin is not available on Alpine Linux"
+
+RUN touch /usr/local/bin/rabbitmqadmin
+
 FROM rabbitmq:4.0-alpine
 
 RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_management; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
-	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf; \
-# grab "rabbitmqadmin" from inside the "rabbitmq_management-X.Y.Z" plugin folder
-# see https://github.com/docker-library/rabbitmq/issues/207
-	cp /plugins/rabbitmq_management-*/priv/www/cli/rabbitmqadmin /usr/local/bin/rabbitmqadmin; \
-	[ -s /usr/local/bin/rabbitmqadmin ]; \
-	chmod +x /usr/local/bin/rabbitmqadmin; \
-	apk add --no-cache python3; \
-	rabbitmqadmin --version
+	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
+
+COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
+
+RUN set -eux; \
+	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
+		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
+		rabbitmqadmin --help; \
+	else \
+		rm -f /tmp/rabbitmqadmin-rust; \
+		echo "[INFO] rabbitmqadmin is not available on this platform."; \
+	fi
 
 EXPOSE 15671 15672

--- a/4.0/ubuntu/Dockerfile
+++ b/4.0/ubuntu/Dockerfile
@@ -6,6 +6,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
 # The official Canonical Ubuntu Focal image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:24.04 AS build-base

--- a/4.0/ubuntu/management/Dockerfile
+++ b/4.0/ubuntu/management/Dockerfile
@@ -6,20 +6,42 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
+FROM rabbitmq:4.0 AS builder
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	arch="$(uname -m)"; \
+	if [ "$arch" = "x86_64" ]; then \
+		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"; \
+		echo "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
+	elif [ "$arch" = "aarch64" ]; then  \
+		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"; \
+		echo "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4 /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
+	else \
+		echo "[INFO] rabbitmqadmin is not available on Ubuntu $arch"; \
+	fi; \
+	chmod +x /usr/local/bin/rabbitmqadmin
+
+RUN touch /usr/local/bin/rabbitmqadmin
+
 FROM rabbitmq:4.0
 
 RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_management; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
-	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf; \
-# grab "rabbitmqadmin" from inside the "rabbitmq_management-X.Y.Z" plugin folder
-# see https://github.com/docker-library/rabbitmq/issues/207
-	cp /plugins/rabbitmq_management-*/priv/www/cli/rabbitmqadmin /usr/local/bin/rabbitmqadmin; \
-	[ -s /usr/local/bin/rabbitmqadmin ]; \
-	chmod +x /usr/local/bin/rabbitmqadmin; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends python3; \
-	rm -rf /var/lib/apt/lists/*; \
-	rabbitmqadmin --version
+	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
+
+COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
+
+RUN set -eux; \
+	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
+		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
+		rabbitmqadmin --help; \
+	else \
+		rm -f /tmp/rabbitmqadmin-rust; \
+		echo "[INFO] rabbitmqadmin is not available on this platform."; \
+	fi
 
 EXPOSE 15671 15672

--- a/4.1/alpine/Dockerfile
+++ b/4.1/alpine/Dockerfile
@@ -6,6 +6,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
 FROM alpine:3.22 AS build-base
 

--- a/4.1/alpine/management/Dockerfile
+++ b/4.1/alpine/management/Dockerfile
@@ -6,18 +6,30 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
+FROM rabbitmq:4.1-alpine AS builder
+
+RUN set -eux; \
+	echo "[INFO] rabbitmqadmin is not available on Alpine Linux"
+
+RUN touch /usr/local/bin/rabbitmqadmin
+
 FROM rabbitmq:4.1-alpine
 
 RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_management; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
-	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf; \
-# grab "rabbitmqadmin" from inside the "rabbitmq_management-X.Y.Z" plugin folder
-# see https://github.com/docker-library/rabbitmq/issues/207
-	cp /plugins/rabbitmq_management-*/priv/www/cli/rabbitmqadmin /usr/local/bin/rabbitmqadmin; \
-	[ -s /usr/local/bin/rabbitmqadmin ]; \
-	chmod +x /usr/local/bin/rabbitmqadmin; \
-	apk add --no-cache python3; \
-	rabbitmqadmin --version
+	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
+
+COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
+
+RUN set -eux; \
+	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
+		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
+		rabbitmqadmin --help; \
+	else \
+		rm -f /tmp/rabbitmqadmin-rust; \
+		echo "[INFO] rabbitmqadmin is not available on this platform."; \
+	fi
 
 EXPOSE 15671 15672

--- a/4.1/ubuntu/Dockerfile
+++ b/4.1/ubuntu/Dockerfile
@@ -6,6 +6,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
 # The official Canonical Ubuntu Focal image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:24.04 AS build-base

--- a/4.1/ubuntu/management/Dockerfile
+++ b/4.1/ubuntu/management/Dockerfile
@@ -6,20 +6,42 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
+FROM rabbitmq:4.1 AS builder
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	arch="$(uname -m)"; \
+	if [ "$arch" = "x86_64" ]; then \
+		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"; \
+		echo "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
+	elif [ "$arch" = "aarch64" ]; then  \
+		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"; \
+		echo "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4 /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
+	else \
+		echo "[INFO] rabbitmqadmin is not available on Ubuntu $arch"; \
+	fi; \
+	chmod +x /usr/local/bin/rabbitmqadmin
+
+RUN touch /usr/local/bin/rabbitmqadmin
+
 FROM rabbitmq:4.1
 
 RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_management; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
-	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf; \
-# grab "rabbitmqadmin" from inside the "rabbitmq_management-X.Y.Z" plugin folder
-# see https://github.com/docker-library/rabbitmq/issues/207
-	cp /plugins/rabbitmq_management-*/priv/www/cli/rabbitmqadmin /usr/local/bin/rabbitmqadmin; \
-	[ -s /usr/local/bin/rabbitmqadmin ]; \
-	chmod +x /usr/local/bin/rabbitmqadmin; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends python3; \
-	rm -rf /var/lib/apt/lists/*; \
-	rabbitmqadmin --version
+	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
+
+COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
+
+RUN set -eux; \
+	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
+		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
+		rabbitmqadmin --help; \
+	else \
+		rm -f /tmp/rabbitmqadmin-rust; \
+		echo "[INFO] rabbitmqadmin is not available on this platform."; \
+	fi
 
 EXPOSE 15671 15672

--- a/4.2/alpine/Dockerfile
+++ b/4.2/alpine/Dockerfile
@@ -6,6 +6,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
 FROM alpine:3.22 AS build-base
 

--- a/4.2/alpine/management/Dockerfile
+++ b/4.2/alpine/management/Dockerfile
@@ -6,18 +6,30 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
+FROM rabbitmq:4.2-alpine AS builder
+
+RUN set -eux; \
+	echo "[INFO] rabbitmqadmin is not available on Alpine Linux"
+
+RUN touch /usr/local/bin/rabbitmqadmin
+
 FROM rabbitmq:4.2-alpine
 
 RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_management; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
-	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf; \
-# grab "rabbitmqadmin" from inside the "rabbitmq_management-X.Y.Z" plugin folder
-# see https://github.com/docker-library/rabbitmq/issues/207
-	cp /plugins/rabbitmq_management-*/priv/www/cli/rabbitmqadmin /usr/local/bin/rabbitmqadmin; \
-	[ -s /usr/local/bin/rabbitmqadmin ]; \
-	chmod +x /usr/local/bin/rabbitmqadmin; \
-	apk add --no-cache python3; \
-	rabbitmqadmin --version
+	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
+
+COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
+
+RUN set -eux; \
+	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
+		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
+		rabbitmqadmin --help; \
+	else \
+		rm -f /tmp/rabbitmqadmin-rust; \
+		echo "[INFO] rabbitmqadmin is not available on this platform."; \
+	fi
 
 EXPOSE 15671 15672

--- a/4.2/ubuntu/Dockerfile
+++ b/4.2/ubuntu/Dockerfile
@@ -6,6 +6,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
 # The official Canonical Ubuntu Focal image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:24.04 AS build-base

--- a/4.2/ubuntu/management/Dockerfile
+++ b/4.2/ubuntu/management/Dockerfile
@@ -6,20 +6,42 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+# vim:noet:
+FROM rabbitmq:4.2 AS builder
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	arch="$(uname -m)"; \
+	if [ "$arch" = "x86_64" ]; then \
+		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"; \
+		echo "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
+	elif [ "$arch" = "aarch64" ]; then  \
+		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"; \
+		echo "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4 /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
+	else \
+		echo "[INFO] rabbitmqadmin is not available on Ubuntu $arch"; \
+	fi; \
+	chmod +x /usr/local/bin/rabbitmqadmin
+
+RUN touch /usr/local/bin/rabbitmqadmin
+
 FROM rabbitmq:4.2
 
 RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_management; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
-	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf; \
-# grab "rabbitmqadmin" from inside the "rabbitmq_management-X.Y.Z" plugin folder
-# see https://github.com/docker-library/rabbitmq/issues/207
-	cp /plugins/rabbitmq_management-*/priv/www/cli/rabbitmqadmin /usr/local/bin/rabbitmqadmin; \
-	[ -s /usr/local/bin/rabbitmqadmin ]; \
-	chmod +x /usr/local/bin/rabbitmqadmin; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends python3; \
-	rm -rf /var/lib/apt/lists/*; \
-	rabbitmqadmin --version
+	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
+
+COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
+
+RUN set -eux; \
+	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
+		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
+		rabbitmqadmin --help; \
+	else \
+		rm -f /tmp/rabbitmqadmin-rust; \
+		echo "[INFO] rabbitmqadmin is not available on this platform."; \
+	fi
 
 EXPOSE 15671 15672

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,3 +1,4 @@
+# vim:noet:
 # Alpine Linux is not officially supported by the RabbitMQ team -- use at your own risk!
 FROM alpine:{{ .alpine.version }} AS build-base
 

--- a/Dockerfile-management.template
+++ b/Dockerfile-management.template
@@ -1,3 +1,31 @@
+# vim:noet:
+FROM {{
+	"rabbitmq:" + env.version
+	+ if env.variant == "alpine" then "-alpine" else "" end
+}} AS builder
+
+{{ if env.variant == "ubuntu" then ( -}}
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	arch="$(uname -m)"; \
+	if [ "$arch" = "x86_64" ]; then \
+		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "{{ .rabbitmqadmin.x86_64_download_url }}"; \
+		echo "{{ .rabbitmqadmin.x86_64_digest }} /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
+	elif [ "$arch" = "aarch64" ]; then  \
+		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "{{ .rabbitmqadmin.aarch64_download_url }}"; \
+		echo "{{ .rabbitmqadmin.aarch64_digest }} /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
+	else \
+		echo "[INFO] rabbitmqadmin is not available on Ubuntu $arch"; \
+	fi; \
+	chmod +x /usr/local/bin/rabbitmqadmin
+{{ ) else ( -}}
+RUN set -eux; \
+	echo "[INFO] rabbitmqadmin is not available on Alpine Linux"
+{{ ) end -}}
+
+RUN touch /usr/local/bin/rabbitmqadmin
+
 FROM {{
 	"rabbitmq:" + env.version
 	+ if env.variant == "alpine" then "-alpine" else "" end
@@ -6,19 +34,17 @@ FROM {{
 RUN set -eux; \
 	rabbitmq-plugins enable --offline rabbitmq_management; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
-	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf; \
-# grab "rabbitmqadmin" from inside the "rabbitmq_management-X.Y.Z" plugin folder
-# see https://github.com/docker-library/rabbitmq/issues/207
-	cp /plugins/rabbitmq_management-*/priv/www/cli/rabbitmqadmin /usr/local/bin/rabbitmqadmin; \
-	[ -s /usr/local/bin/rabbitmqadmin ]; \
-	chmod +x /usr/local/bin/rabbitmqadmin; \
-{{ if env.variant == "alpine" then ( -}}
-	apk add --no-cache python3; \
-{{ ) else ( -}}
-	apt-get update; \
-	apt-get install -y --no-install-recommends python3; \
-	rm -rf /var/lib/apt/lists/*; \
-{{ ) end -}}
-	rabbitmqadmin --version
+	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
+
+COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
+
+RUN set -eux; \
+	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
+		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
+		rabbitmqadmin --help; \
+	else \
+		rm -f /tmp/rabbitmqadmin-rust; \
+		echo "[INFO] rabbitmqadmin is not available on this platform."; \
+	fi
 
 EXPOSE 15671 15672

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -1,3 +1,4 @@
+# vim:noet:
 # The official Canonical Ubuntu Focal image is ideal from a security perspective,
 # especially for the enterprises that we, the RabbitMQ team, have to deal with
 FROM ubuntu:{{ .ubuntu.version }} AS build-base

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vim:noet:
 set -Eeuo pipefail
 
 [ -f versions.json ] # run "versions.sh" first

--- a/versions.json
+++ b/versions.json
@@ -11,6 +11,12 @@
       "sha256": "932d091933f818d89c2cf7a8c23d84781bbae4b1ee7b846e8676e22768570cae",
       "version": "26.2.5.16"
     },
+    "rabbitmqadmin": {
+      "aarch64_digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
+      "aarch64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu",
+      "x86_64_digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
+      "x86_64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
+    },
     "ubuntu": {
       "version": "24.04"
     },
@@ -28,6 +34,12 @@
     "otp": {
       "sha256": "658529f94cc5b8833907aa680a5e979e67c32dd6ebba69ed3b90b95f526ccda2",
       "version": "27.3.4.6"
+    },
+    "rabbitmqadmin": {
+      "aarch64_digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
+      "aarch64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu",
+      "x86_64_digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
+      "x86_64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
     },
     "ubuntu": {
       "version": "24.04"
@@ -47,6 +59,12 @@
       "sha256": "658529f94cc5b8833907aa680a5e979e67c32dd6ebba69ed3b90b95f526ccda2",
       "version": "27.3.4.6"
     },
+    "rabbitmqadmin": {
+      "aarch64_digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
+      "aarch64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu",
+      "x86_64_digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
+      "x86_64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
+    },
     "ubuntu": {
       "version": "24.04"
     },
@@ -64,6 +82,12 @@
     "otp": {
       "sha256": "658529f94cc5b8833907aa680a5e979e67c32dd6ebba69ed3b90b95f526ccda2",
       "version": "27.3.4.6"
+    },
+    "rabbitmqadmin": {
+      "aarch64_digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
+      "aarch64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu",
+      "x86_64_digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
+      "x86_64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
     },
     "ubuntu": {
       "version": "24.04"


### PR DESCRIPTION
Fixes #768 

The RabbitMQ management images now include the Rust-based `rabbitmqadmin-ng` CLI tool when possible. The deprecated Python version of `rabbitmqadmin` will no longer be available.

This change adds a two-stage build to `Dockerfile-management.template`:
- **Download stage**: Attempts to download `rabbitmqadmin-ng` from GitHub release for the target architecture on Ubuntu only.
- **Final stage**: Copies the Rust binary if download succeeded.

The `versions.sh` script fetches the latest `rabbitmqadmin-ng` release tag from the GitHub API and calculates SHA256 checksums and download URLs for the release artifacts for x86_64 and aarch64 architectures into `versions.json` and templated into the generated management Dockerfiles.