### PR TITLE
Slightly refactor new `rabbitmqadmin` code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-*.tar.gz
-*.zip
-rustup-init.sh
 .jq-template.awk

--- a/3.13/alpine/management/Dockerfile
+++ b/3.13/alpine/management/Dockerfile
@@ -7,12 +7,6 @@
 #
 
 # vim:noet:
-FROM rabbitmq:3.13-alpine AS builder
-
-RUN set -eux; \
-	echo "[INFO] rabbitmqadmin is not available on Alpine Linux"
-
-RUN touch /usr/local/bin/rabbitmqadmin
 
 FROM rabbitmq:3.13-alpine
 
@@ -21,15 +15,6 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
-
-RUN set -eux; \
-	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
-		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
-		rabbitmqadmin --help; \
-	else \
-		rm -f /tmp/rabbitmqadmin-rust; \
-		echo "[INFO] rabbitmqadmin is not available on this platform."; \
-	fi
+# rabbitmqadmin is not available (yet) on Alpine Linux; https://github.com/docker-library/rabbitmq/pull/780#issuecomment-3634857588
 
 EXPOSE 15671 15672

--- a/3.13/ubuntu/management/Dockerfile
+++ b/3.13/ubuntu/management/Dockerfile
@@ -7,24 +7,6 @@
 #
 
 # vim:noet:
-FROM rabbitmq:3.13 AS builder
-
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends wget; \
-	arch="$(uname -m)"; \
-	if [ "$arch" = "x86_64" ]; then \
-		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"; \
-		echo "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
-	elif [ "$arch" = "aarch64" ]; then  \
-		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"; \
-		echo "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4 /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
-	else \
-		echo "[INFO] rabbitmqadmin is not available on Ubuntu $arch"; \
-	fi; \
-	chmod +x /usr/local/bin/rabbitmqadmin
-
-RUN touch /usr/local/bin/rabbitmqadmin
 
 FROM rabbitmq:3.13
 
@@ -33,15 +15,27 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
-
 RUN set -eux; \
-	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
-		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
-		rabbitmqadmin --help; \
-	else \
-		rm -f /tmp/rabbitmqadmin-rust; \
-		echo "[INFO] rabbitmqadmin is not available on this platform."; \
-	fi
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+		'amd64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu'; digest='a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb' ;; \
+		'arm64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu'; digest='a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4' ;; \
+		*) echo "[INFO] rabbitmqadmin is not available on $arch (yet?)"; exit 0; \
+	esac; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates wget; \
+	\
+	wget -O /usr/local/bin/rabbitmqadmin "$url"; \
+	echo "$digest */usr/local/bin/rabbitmqadmin" | sha256sum --strict --check -; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get dist-clean; \
+	\
+	chmod +x /usr/local/bin/rabbitmqadmin; \
+	rabbitmqadmin --help
 
 EXPOSE 15671 15672

--- a/4.0/alpine/management/Dockerfile
+++ b/4.0/alpine/management/Dockerfile
@@ -7,12 +7,6 @@
 #
 
 # vim:noet:
-FROM rabbitmq:4.0-alpine AS builder
-
-RUN set -eux; \
-	echo "[INFO] rabbitmqadmin is not available on Alpine Linux"
-
-RUN touch /usr/local/bin/rabbitmqadmin
 
 FROM rabbitmq:4.0-alpine
 
@@ -21,15 +15,6 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
-
-RUN set -eux; \
-	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
-		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
-		rabbitmqadmin --help; \
-	else \
-		rm -f /tmp/rabbitmqadmin-rust; \
-		echo "[INFO] rabbitmqadmin is not available on this platform."; \
-	fi
+# rabbitmqadmin is not available (yet) on Alpine Linux; https://github.com/docker-library/rabbitmq/pull/780#issuecomment-3634857588
 
 EXPOSE 15671 15672

--- a/4.0/ubuntu/management/Dockerfile
+++ b/4.0/ubuntu/management/Dockerfile
@@ -7,24 +7,6 @@
 #
 
 # vim:noet:
-FROM rabbitmq:4.0 AS builder
-
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends wget; \
-	arch="$(uname -m)"; \
-	if [ "$arch" = "x86_64" ]; then \
-		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"; \
-		echo "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
-	elif [ "$arch" = "aarch64" ]; then  \
-		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"; \
-		echo "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4 /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
-	else \
-		echo "[INFO] rabbitmqadmin is not available on Ubuntu $arch"; \
-	fi; \
-	chmod +x /usr/local/bin/rabbitmqadmin
-
-RUN touch /usr/local/bin/rabbitmqadmin
 
 FROM rabbitmq:4.0
 
@@ -33,15 +15,27 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
-
 RUN set -eux; \
-	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
-		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
-		rabbitmqadmin --help; \
-	else \
-		rm -f /tmp/rabbitmqadmin-rust; \
-		echo "[INFO] rabbitmqadmin is not available on this platform."; \
-	fi
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+		'amd64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu'; digest='a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb' ;; \
+		'arm64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu'; digest='a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4' ;; \
+		*) echo "[INFO] rabbitmqadmin is not available on $arch (yet?)"; exit 0; \
+	esac; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates wget; \
+	\
+	wget -O /usr/local/bin/rabbitmqadmin "$url"; \
+	echo "$digest */usr/local/bin/rabbitmqadmin" | sha256sum --strict --check -; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get dist-clean; \
+	\
+	chmod +x /usr/local/bin/rabbitmqadmin; \
+	rabbitmqadmin --help
 
 EXPOSE 15671 15672

--- a/4.1/alpine/management/Dockerfile
+++ b/4.1/alpine/management/Dockerfile
@@ -7,12 +7,6 @@
 #
 
 # vim:noet:
-FROM rabbitmq:4.1-alpine AS builder
-
-RUN set -eux; \
-	echo "[INFO] rabbitmqadmin is not available on Alpine Linux"
-
-RUN touch /usr/local/bin/rabbitmqadmin
 
 FROM rabbitmq:4.1-alpine
 
@@ -21,15 +15,6 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
-
-RUN set -eux; \
-	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
-		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
-		rabbitmqadmin --help; \
-	else \
-		rm -f /tmp/rabbitmqadmin-rust; \
-		echo "[INFO] rabbitmqadmin is not available on this platform."; \
-	fi
+# rabbitmqadmin is not available (yet) on Alpine Linux; https://github.com/docker-library/rabbitmq/pull/780#issuecomment-3634857588
 
 EXPOSE 15671 15672

--- a/4.1/ubuntu/management/Dockerfile
+++ b/4.1/ubuntu/management/Dockerfile
@@ -7,24 +7,6 @@
 #
 
 # vim:noet:
-FROM rabbitmq:4.1 AS builder
-
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends wget; \
-	arch="$(uname -m)"; \
-	if [ "$arch" = "x86_64" ]; then \
-		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"; \
-		echo "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
-	elif [ "$arch" = "aarch64" ]; then  \
-		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"; \
-		echo "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4 /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
-	else \
-		echo "[INFO] rabbitmqadmin is not available on Ubuntu $arch"; \
-	fi; \
-	chmod +x /usr/local/bin/rabbitmqadmin
-
-RUN touch /usr/local/bin/rabbitmqadmin
 
 FROM rabbitmq:4.1
 
@@ -33,15 +15,27 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
-
 RUN set -eux; \
-	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
-		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
-		rabbitmqadmin --help; \
-	else \
-		rm -f /tmp/rabbitmqadmin-rust; \
-		echo "[INFO] rabbitmqadmin is not available on this platform."; \
-	fi
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+		'amd64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu'; digest='a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb' ;; \
+		'arm64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu'; digest='a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4' ;; \
+		*) echo "[INFO] rabbitmqadmin is not available on $arch (yet?)"; exit 0; \
+	esac; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates wget; \
+	\
+	wget -O /usr/local/bin/rabbitmqadmin "$url"; \
+	echo "$digest */usr/local/bin/rabbitmqadmin" | sha256sum --strict --check -; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get dist-clean; \
+	\
+	chmod +x /usr/local/bin/rabbitmqadmin; \
+	rabbitmqadmin --help
 
 EXPOSE 15671 15672

--- a/4.2/alpine/management/Dockerfile
+++ b/4.2/alpine/management/Dockerfile
@@ -7,12 +7,6 @@
 #
 
 # vim:noet:
-FROM rabbitmq:4.2-alpine AS builder
-
-RUN set -eux; \
-	echo "[INFO] rabbitmqadmin is not available on Alpine Linux"
-
-RUN touch /usr/local/bin/rabbitmqadmin
 
 FROM rabbitmq:4.2-alpine
 
@@ -21,15 +15,6 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
-
-RUN set -eux; \
-	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
-		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
-		rabbitmqadmin --help; \
-	else \
-		rm -f /tmp/rabbitmqadmin-rust; \
-		echo "[INFO] rabbitmqadmin is not available on this platform."; \
-	fi
+# rabbitmqadmin is not available (yet) on Alpine Linux; https://github.com/docker-library/rabbitmq/pull/780#issuecomment-3634857588
 
 EXPOSE 15671 15672

--- a/4.2/ubuntu/management/Dockerfile
+++ b/4.2/ubuntu/management/Dockerfile
@@ -7,24 +7,6 @@
 #
 
 # vim:noet:
-FROM rabbitmq:4.2 AS builder
-
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends wget; \
-	arch="$(uname -m)"; \
-	if [ "$arch" = "x86_64" ]; then \
-		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"; \
-		echo "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
-	elif [ "$arch" = "aarch64" ]; then  \
-		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"; \
-		echo "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4 /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
-	else \
-		echo "[INFO] rabbitmqadmin is not available on Ubuntu $arch"; \
-	fi; \
-	chmod +x /usr/local/bin/rabbitmqadmin
-
-RUN touch /usr/local/bin/rabbitmqadmin
 
 FROM rabbitmq:4.2
 
@@ -33,15 +15,27 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
-
 RUN set -eux; \
-	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
-		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
-		rabbitmqadmin --help; \
-	else \
-		rm -f /tmp/rabbitmqadmin-rust; \
-		echo "[INFO] rabbitmqadmin is not available on this platform."; \
-	fi
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+		'amd64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu'; digest='a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb' ;; \
+		'arm64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu'; digest='a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4' ;; \
+		*) echo "[INFO] rabbitmqadmin is not available on $arch (yet?)"; exit 0; \
+	esac; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates wget; \
+	\
+	wget -O /usr/local/bin/rabbitmqadmin "$url"; \
+	echo "$digest */usr/local/bin/rabbitmqadmin" | sha256sum --strict --check -; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get dist-clean; \
+	\
+	chmod +x /usr/local/bin/rabbitmqadmin; \
+	rabbitmqadmin --help
 
 EXPOSE 15671 15672

--- a/Dockerfile-management.template
+++ b/Dockerfile-management.template
@@ -1,30 +1,4 @@
 # vim:noet:
-FROM {{
-	"rabbitmq:" + env.version
-	+ if env.variant == "alpine" then "-alpine" else "" end
-}} AS builder
-
-{{ if env.variant == "ubuntu" then ( -}}
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends wget; \
-	arch="$(uname -m)"; \
-	if [ "$arch" = "x86_64" ]; then \
-		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "{{ .rabbitmqadmin.x86_64_download_url }}"; \
-		echo "{{ .rabbitmqadmin.x86_64_digest }} /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
-	elif [ "$arch" = "aarch64" ]; then  \
-		wget --quiet --output-document=/usr/local/bin/rabbitmqadmin "{{ .rabbitmqadmin.aarch64_download_url }}"; \
-		echo "{{ .rabbitmqadmin.aarch64_digest }} /usr/local/bin/rabbitmqadmin" | sha256sum --check --strict -; \
-	else \
-		echo "[INFO] rabbitmqadmin is not available on Ubuntu $arch"; \
-	fi; \
-	chmod +x /usr/local/bin/rabbitmqadmin
-{{ ) else ( -}}
-RUN set -eux; \
-	echo "[INFO] rabbitmqadmin is not available on Alpine Linux"
-{{ ) end -}}
-
-RUN touch /usr/local/bin/rabbitmqadmin
 
 FROM {{
 	"rabbitmq:" + env.version
@@ -36,15 +10,51 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-COPY --from=builder /usr/local/bin/rabbitmqadmin /tmp/rabbitmqadmin-rust
-
+{{ if env.variant == "alpine" then ( -}}
+# rabbitmqadmin is not available (yet) on Alpine Linux; https://github.com/docker-library/rabbitmq/pull/780#issuecomment-3634857588
+{{ ) else ( -}}
 RUN set -eux; \
-	if [ -s /tmp/rabbitmqadmin-rust ] && [ -x /tmp/rabbitmqadmin-rust ]; then \
-		mv /tmp/rabbitmqadmin-rust /usr/local/bin/rabbitmqadmin; \
-		rabbitmqadmin --help; \
-	else \
-		rm -f /tmp/rabbitmqadmin-rust; \
-		echo "[INFO] rabbitmqadmin is not available on this platform."; \
-	fi
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+{{ .rabbitmqadmin.arches | to_entries | map( -}}
+{{ def deb_arches: {
+	# conversion mapping of bashbrew architectures to Debian architectures
+	# (most of these aren't supported/needed, but cargo-culting them makes sure nobody has to look these up in the future if the list grows)
+	# https://salsa.debian.org/dpkg-team/dpkg/-/blob/main/data/cputable
+	# https://wiki.debian.org/ArchitectureSpecificsMemo#Architecture_baselines
+	# https://deb.debian.org/debian/dists/unstable/Release ("Architectures:")
+	# http://deb.debian.org/debian/dists/unstable/main/
+	# http://deb.debian.org/debian/dists/stable/main/
+	# https://deb.debian.org/debian-ports/dists/unstable/main/
+	amd64: "amd64",
+	arm32v5: "armel",
+	arm32v7: "armhf",
+	arm64v8: "arm64",
+	i386: "i386",
+	mips64le: "mips64el",
+	ppc64le: "ppc64el",
+	riscv64: "riscv64",
+	s390x: "s390x",
+} -}}
+		{{ deb_arches[.key] // empty | @sh }}) url={{ .value.url | @sh }}; digest={{ .value.digest | @sh }} ;; \
+{{ ) | join("") -}}
+		*) echo "[INFO] rabbitmqadmin is not available on $arch (yet?)"; exit 0; \
+	esac; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates wget; \
+	\
+	wget -O /usr/local/bin/rabbitmqadmin "$url"; \
+	echo "$digest */usr/local/bin/rabbitmqadmin" | sha256sum --strict --check -; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	apt-get dist-clean; \
+	\
+	chmod +x /usr/local/bin/rabbitmqadmin; \
+	rabbitmqadmin --help
+{{ ) end -}}
 
 EXPOSE 15671 15672

--- a/versions.json
+++ b/versions.json
@@ -12,10 +12,17 @@
       "version": "26.2.5.16"
     },
     "rabbitmqadmin": {
-      "aarch64_digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
-      "aarch64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu",
-      "x86_64_digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
-      "x86_64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
+      "arches": {
+        "amd64": {
+          "digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
+        },
+        "arm64v8": {
+          "digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"
+        }
+      },
+      "version": "2.17.0"
     },
     "ubuntu": {
       "version": "24.04"
@@ -36,10 +43,17 @@
       "version": "27.3.4.6"
     },
     "rabbitmqadmin": {
-      "aarch64_digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
-      "aarch64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu",
-      "x86_64_digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
-      "x86_64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
+      "arches": {
+        "amd64": {
+          "digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
+        },
+        "arm64v8": {
+          "digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"
+        }
+      },
+      "version": "2.17.0"
     },
     "ubuntu": {
       "version": "24.04"
@@ -60,10 +74,17 @@
       "version": "27.3.4.6"
     },
     "rabbitmqadmin": {
-      "aarch64_digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
-      "aarch64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu",
-      "x86_64_digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
-      "x86_64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
+      "arches": {
+        "amd64": {
+          "digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
+        },
+        "arm64v8": {
+          "digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"
+        }
+      },
+      "version": "2.17.0"
     },
     "ubuntu": {
       "version": "24.04"
@@ -84,10 +105,17 @@
       "version": "27.3.4.6"
     },
     "rabbitmqadmin": {
-      "aarch64_digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
-      "aarch64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu",
-      "x86_64_digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
-      "x86_64_download_url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
+      "arches": {
+        "amd64": {
+          "digest": "a0995c7bb4597f33cddefce80dc2e234c571d8716c8ba946b1e288f3ab6e6dbb",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-x86_64-unknown-linux-gnu"
+        },
+        "arm64v8": {
+          "digest": "a90d65072eb3fe4cc5883b7396cdf180cf883111c0626a80a2ad6256b87879d4",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.17.0/rabbitmqadmin-2.17.0-aarch64-unknown-linux-gnu"
+        }
+      },
+      "version": "2.17.0"
     },
     "ubuntu": {
       "version": "24.04"

--- a/versions.sh
+++ b/versions.sh
@@ -46,6 +46,43 @@ else
 fi
 versions=( "${versions[@]%/}" )
 
+rabbitmqadmin="$(
+	wget --quiet --output-document=- \
+		--header='Accept: application/vnd.github+json' \
+		--header='X-GitHub-Api-Version: 2022-11-28' \
+		https://api.github.com/repos/rabbitmq/rabbitmqadmin-ng/releases/latest \
+	| jq -c '
+		{
+			version: (.tag_name | ltrimstr("v")),
+			arches: (
+				.assets
+				| map({
+					key: (
+						.name
+						| first(
+							(
+								[ "-x86_64-unknown-linux-gnu$", "amd64" ],
+								[ "-aarch64-unknown-linux-gnu$", "arm64v8" ],
+								# TODO [ "-x86_64-unknown-linux-musl$", "alpine-amd64" ],
+								# TODO [ "-aarch64-unknown-linux-musl$", "alpine-arm64v8" ],
+								empty
+							) as [ $regex, $arch ]
+							| if test($regex) then $arch else empty end
+						)
+					),
+					value: {
+						url: .browser_download_url,
+						digest: (.digest | ltrimstr("sha256:")),
+					},
+				})
+				| sort_by(.key)
+				| from_entries
+			),
+		}
+	'
+)"
+export rabbitmqadmin
+
 for version in "${versions[@]}"; do
 	export version
 
@@ -161,36 +198,7 @@ for version in "${versions[@]}"; do
 	ubuntuVersion="${ubuntuVersions[$rcVersion]}"
 	export ubuntuVersion
 
-	if [[ ${rmqadmin_version:-undefined} == 'undefined' ]]
-	then
-		rmqadmin_release_json="$(wget --quiet --output-document=- \
-			--header='Accept: application/vnd.github+json' \
-			--header='X-GitHub-Api-Version: 2022-11-28' \
-			https://api.github.com/repos/rabbitmq/rabbitmqadmin-ng/releases/latest)"
-
-		rmqadmin_version="$(echo "$rmqadmin_release_json" | jq -r '.tag_name')"
-		rmqadmin_version="${rmqadmin_version#v}" # NOTE: removes leading "v"
-		readonly rmqadmin_version
-
-		rmqadmin_aarch64_download_url="$(echo "$rmqadmin_release_json" | jq -r '.assets[] | select(.name | test(".*aarch64.*linux.*")) | .browser_download_url')"
-		readonly rmqadmin_aarch64_download_url
-
-		rmqadmin_aarch64_digest="$(echo "$rmqadmin_release_json" | jq -r '.assets[] | select(.name | test(".*aarch64.*linux.*")) | .digest | split("sha256:")[1]')"
-		readonly rmqadmin_aarch64_digest
-
-		rmqadmin_x86_64_download_url="$(echo "$rmqadmin_release_json" | jq -r '.assets[] | select(.name | test(".*x86_64.*linux.*")) | .browser_download_url')"
-		readonly rmqadmin_x86_64_download_url
-
-		rmqadmin_x86_64_digest="$(echo "$rmqadmin_release_json" | jq -r '.assets[] | select(.name | test(".*x86_64.*linux.*")) | .digest | split("sha256:")[1]')"
-		readonly rmqadmin_x86_64_digest
-
-		unset rmqadmin_release_json
-
-		export rmqadmin_aarch64_download_url rmqadmin_aarch64_digest \
-			rmqadmin_x86_64_download_url rmqadmin_x86_64_digest
-	fi
-
-	echo "$version: $fullVersion (otp $otpVersion, openssl $opensslVersion, rabbitmqadmin $rmqadmin_version, alpine, $alpineVersion, ubuntu $ubuntuVersion)"
+	echo "$version: $fullVersion (otp $otpVersion, openssl $opensslVersion, alpine $alpineVersion, ubuntu $ubuntuVersion)"
 
 	json="$(
 		jq <<<"$json" -c '
@@ -210,12 +218,7 @@ for version in "${versions[@]}"; do
 				ubuntu: {
 					version: env.ubuntuVersion
 				},
-				rabbitmqadmin: {
-					aarch64_download_url: env.rmqadmin_aarch64_download_url,
-					aarch64_digest: env.rmqadmin_aarch64_digest,
-					x86_64_download_url: env.rmqadmin_x86_64_download_url,
-					x86_64_digest: env.rmqadmin_x86_64_digest,
-				},
+				rabbitmqadmin: (env.rabbitmqadmin | fromjson),
 			}
 		'
 	)"


### PR DESCRIPTION
This is a follow-up to #780 -- I'm happy to discuss any of this further (and to be explicitly clear, I'm very open to changes!) :heart:

- align on "bashbrew architectures" for representing the architecture strings (matching the `Architectures:` lines in our downstream `library/rabbitmq` file; this makes it easier to filter that list later if we so choose)
- avoid multi-stage build, especially to avoid the empty file copying/weirdness
- we always need the `rabbitmqadmin` data, so we should query it before the loop (and pre-process it since the data is the same for every single iteration of the loop)
- store `version` in the `rabbitmqadmin` block (our automation uses this for making nicer commit messages like "Update 4.0 to rabbitmqadmin 2.17.1" instead of just "Update 4.0" which is what the current code will lead to)
- use `dpkg --print-architecture` instead of `uname -m` for architecture detection (the former is "userspace architecture" detection, which more closely matches what we need than the latter's "kernel architecture" detection)