### PR TITLE
Add `rabbitmqadmin-ng` to `*-alpine-management`

### DIFF
--- a/4.0/alpine/management/Dockerfile
+++ b/4.0/alpine/management/Dockerfile
@@ -15,6 +15,19 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-# rabbitmqadmin is not available (yet) on Alpine Linux; https://github.com/docker-library/rabbitmq/pull/780#issuecomment-3634857588
+RUN set -eux; \
+	arch="$(apk --print-arch)"; \
+	\
+	case "$arch" in \
+		'x86_64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-x86_64-unknown-linux-musl'; digest='017747084312a47c38eca52942e6f0dd06f5ab845ac0ce7e744d63de253cd0d6' ;; \
+		'aarch64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-aarch64-unknown-linux-musl'; digest='13a9f4f0457c95dbe5739a357663b18bda927b277ebdefe5038f0f9bf2b96570' ;; \
+		*) echo "[INFO] rabbitmqadmin is not available on $arch (yet?)"; exit 0; \
+	esac; \
+	\
+	wget -O /usr/local/bin/rabbitmqadmin "$url"; \
+	echo "$digest */usr/local/bin/rabbitmqadmin" | sha256sum -c -; \
+	\
+	chmod +x /usr/local/bin/rabbitmqadmin; \
+	rabbitmqadmin --help
 
 EXPOSE 15671 15672

--- a/4.1/alpine/management/Dockerfile
+++ b/4.1/alpine/management/Dockerfile
@@ -15,6 +15,19 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-# rabbitmqadmin is not available (yet) on Alpine Linux; https://github.com/docker-library/rabbitmq/pull/780#issuecomment-3634857588
+RUN set -eux; \
+	arch="$(apk --print-arch)"; \
+	\
+	case "$arch" in \
+		'x86_64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-x86_64-unknown-linux-musl'; digest='017747084312a47c38eca52942e6f0dd06f5ab845ac0ce7e744d63de253cd0d6' ;; \
+		'aarch64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-aarch64-unknown-linux-musl'; digest='13a9f4f0457c95dbe5739a357663b18bda927b277ebdefe5038f0f9bf2b96570' ;; \
+		*) echo "[INFO] rabbitmqadmin is not available on $arch (yet?)"; exit 0; \
+	esac; \
+	\
+	wget -O /usr/local/bin/rabbitmqadmin "$url"; \
+	echo "$digest */usr/local/bin/rabbitmqadmin" | sha256sum -c -; \
+	\
+	chmod +x /usr/local/bin/rabbitmqadmin; \
+	rabbitmqadmin --help
 
 EXPOSE 15671 15672

--- a/4.2/alpine/management/Dockerfile
+++ b/4.2/alpine/management/Dockerfile
@@ -15,6 +15,19 @@ RUN set -eux; \
 # make sure the metrics collector is re-enabled (disabled in the base image for Prometheus-style metrics by default)
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
-# rabbitmqadmin is not available (yet) on Alpine Linux; https://github.com/docker-library/rabbitmq/pull/780#issuecomment-3634857588
+RUN set -eux; \
+	arch="$(apk --print-arch)"; \
+	\
+	case "$arch" in \
+		'x86_64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-x86_64-unknown-linux-musl'; digest='017747084312a47c38eca52942e6f0dd06f5ab845ac0ce7e744d63de253cd0d6' ;; \
+		'aarch64') url='https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-aarch64-unknown-linux-musl'; digest='13a9f4f0457c95dbe5739a357663b18bda927b277ebdefe5038f0f9bf2b96570' ;; \
+		*) echo "[INFO] rabbitmqadmin is not available on $arch (yet?)"; exit 0; \
+	esac; \
+	\
+	wget -O /usr/local/bin/rabbitmqadmin "$url"; \
+	echo "$digest */usr/local/bin/rabbitmqadmin" | sha256sum -c -; \
+	\
+	chmod +x /usr/local/bin/rabbitmqadmin; \
+	rabbitmqadmin --help
 
 EXPOSE 15671 15672

--- a/Dockerfile-management.template
+++ b/Dockerfile-management.template
@@ -11,7 +11,25 @@ RUN set -eux; \
 	rm -f /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
 
 {{ if env.variant == "alpine" then ( -}}
-# rabbitmqadmin is not available (yet) on Alpine Linux; https://github.com/docker-library/rabbitmq/pull/780#issuecomment-3634857588
+RUN set -eux; \
+	arch="$(apk --print-arch)"; \
+	\
+	case "$arch" in \
+{{ .rabbitmqadmin.arches | to_entries | map( -}}
+{{ def alpine_arches: {
+	"alpine-amd64": "x86_64",
+	"alpine-arm64v8": "aarch64",
+} -}}
+		{{ alpine_arches[.key] // empty | @sh }}) url={{ .value.url | @sh }}; digest={{ .value.digest | @sh }} ;; \
+{{ ) | join("") -}}
+		*) echo "[INFO] rabbitmqadmin is not available on $arch (yet?)"; exit 0; \
+	esac; \
+	\
+	wget -O /usr/local/bin/rabbitmqadmin "$url"; \
+	echo "$digest */usr/local/bin/rabbitmqadmin" | sha256sum -c -; \
+	\
+	chmod +x /usr/local/bin/rabbitmqadmin; \
+	rabbitmqadmin --help
 {{ ) else ( -}}
 RUN set -eux; \
 	arch="$(dpkg --print-architecture)"; \

--- a/versions.json
+++ b/versions.json
@@ -13,6 +13,14 @@
     },
     "rabbitmqadmin": {
       "arches": {
+        "alpine-amd64": {
+          "digest": "017747084312a47c38eca52942e6f0dd06f5ab845ac0ce7e744d63de253cd0d6",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-x86_64-unknown-linux-musl"
+        },
+        "alpine-arm64v8": {
+          "digest": "13a9f4f0457c95dbe5739a357663b18bda927b277ebdefe5038f0f9bf2b96570",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-aarch64-unknown-linux-musl"
+        },
         "amd64": {
           "digest": "eb3b573aeaa50b3ad279afd1c1e2bfa4d41ff0a4c0c1740bb31ddc49fa9fbd06",
           "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-x86_64-unknown-linux-gnu"
@@ -44,6 +52,14 @@
     },
     "rabbitmqadmin": {
       "arches": {
+        "alpine-amd64": {
+          "digest": "017747084312a47c38eca52942e6f0dd06f5ab845ac0ce7e744d63de253cd0d6",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-x86_64-unknown-linux-musl"
+        },
+        "alpine-arm64v8": {
+          "digest": "13a9f4f0457c95dbe5739a357663b18bda927b277ebdefe5038f0f9bf2b96570",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-aarch64-unknown-linux-musl"
+        },
         "amd64": {
           "digest": "eb3b573aeaa50b3ad279afd1c1e2bfa4d41ff0a4c0c1740bb31ddc49fa9fbd06",
           "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-x86_64-unknown-linux-gnu"
@@ -75,6 +91,14 @@
     },
     "rabbitmqadmin": {
       "arches": {
+        "alpine-amd64": {
+          "digest": "017747084312a47c38eca52942e6f0dd06f5ab845ac0ce7e744d63de253cd0d6",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-x86_64-unknown-linux-musl"
+        },
+        "alpine-arm64v8": {
+          "digest": "13a9f4f0457c95dbe5739a357663b18bda927b277ebdefe5038f0f9bf2b96570",
+          "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-aarch64-unknown-linux-musl"
+        },
         "amd64": {
           "digest": "eb3b573aeaa50b3ad279afd1c1e2bfa4d41ff0a4c0c1740bb31ddc49fa9fbd06",
           "url": "https://github.com/rabbitmq/rabbitmqadmin-ng/releases/download/v2.20.0/rabbitmqadmin-2.20.0-x86_64-unknown-linux-gnu"

--- a/versions.sh
+++ b/versions.sh
@@ -59,8 +59,8 @@ rabbitmqadmin="$(
 							(
 								[ "-x86_64-unknown-linux-gnu$", "amd64" ],
 								[ "-aarch64-unknown-linux-gnu$", "arm64v8" ],
-								# TODO [ "-x86_64-unknown-linux-musl$", "alpine-amd64" ],
-								# TODO [ "-aarch64-unknown-linux-musl$", "alpine-arm64v8" ],
+								[ "-x86_64-unknown-linux-musl$", "alpine-amd64" ],
+								[ "-aarch64-unknown-linux-musl$", "alpine-arm64v8" ],
 								empty
 							) as [ $regex, $arch ]
 							| if test($regex) then $arch else empty end


### PR DESCRIPTION
Fixes #786 

@michaelklishin recently added a build of `rabbitmqadmin-ng` that is compatible with Alpine Linux.